### PR TITLE
ci: add concurrency, reduce Python matrix to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,16 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add concurrency group to cancel in-progress CI runs when new commits are pushed to the same PR
- Reduce Python test matrix from `["3.10", "3.11", "3.12"]` to `["3.12"]` only — eliminates 2 redundant matrix jobs per CI run

## Test plan
- [ ] Verify CI passes on this PR with Python 3.12 only
- [ ] Push a second commit to verify concurrency cancellation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)