### PR TITLE
Fix create_parameter to use UserParameters.add() directly

### DIFF
--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -1531,9 +1531,8 @@ class CommandHandler:
                          comment: str = None):
         design = self._design()
         params = design.userParameters
-        inp = params.createInput(name, adsk.core.ValueInput.createByReal(value),
-                                 unit, comment or "")
-        params.add(inp)
+        params.add(name, adsk.core.ValueInput.createByReal(value),
+                   unit, comment or "")
         return {"created": True, "name": name, "value": value, "unit": unit}
 
     def set_parameter(self, name: str, value: float):


### PR DESCRIPTION
Fixes #4

## Problem

`create_parameter` called `params.createInput()` which does not exist on the Fusion 360 `UserParameters` collection, causing an `AttributeError` at runtime every time.

## Fix

Use `UserParameters.add(name, valueInput, unit, comment)` directly, which is the correct API.

```python
# Before
inp = params.createInput(name, adsk.core.ValueInput.createByReal(value), unit, comment or "")
params.add(inp)

# After
params.add(name, adsk.core.ValueInput.createByReal(value), unit, comment or "")
```

`set_parameter` and `delete_parameter` were reviewed and are unaffected.