### PR TITLE
Add design type safety: get/set_design_type tools + undo guard

### DIFF
--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -135,6 +135,9 @@ class CommandHandler:
                 "cam_post_process":     self.cam_post_process,
                 # health
                 "ping":                 self.ping,
+                # design type safety
+                "get_design_type":      self.get_design_type,
+                "set_design_type":      self.set_design_type,
             }
 
         cmd_type = command.get("type")
@@ -1121,11 +1124,31 @@ class CommandHandler:
         return {"deleted": True}
 
     def undo(self):
-        # Execute undo via UI command
+        design = self._design()
+        type_before = design.designType
+
         cmd_def = self.ui.commandDefinitions.itemById('UndoCommand')
         if cmd_def:
             cmd_def.execute()
-        return {"undone": True}
+
+        # Check if undo silently switched design type (Parametric → Direct)
+        adsk.doEvents()  # let Fusion process the undo
+        type_after = design.designType
+        if type_before != type_after:
+            # Undo the undo — redo to restore original state
+            redo_def = self.ui.commandDefinitions.itemById('RedoCommand')
+            if redo_def:
+                redo_def.execute()
+                adsk.doEvents()
+            raise RuntimeError(
+                f"Undo aborted: would have changed design type from "
+                f"{'Parametric' if type_before == 1 else 'Direct'} to "
+                f"{'Parametric' if type_after == 1 else 'Direct'}. "
+                f"The undo was automatically reversed (redo). "
+                f"Delete the failed feature explicitly instead."
+            )
+
+        return {"undone": True, "design_type": type_after}
 
     # ------------------------------------------------------------------
     # Direct Primitives (via TemporaryBRepManager)
@@ -1918,15 +1941,68 @@ class CommandHandler:
         return {"pong": True}
 
     # ------------------------------------------------------------------
+    # Design type safety
+    # ------------------------------------------------------------------
+
+    def get_design_type(self):
+        """Return current design type: 'parametric' or 'direct'."""
+        design = self._design()
+        dt = design.designType
+        is_parametric = dt == adsk.fusion.DesignTypes.ParametricDesignType
+        return {
+            "design_type": "parametric" if is_parametric else "direct",
+            "design_type_id": dt,
+        }
+
+    def set_design_type(self, design_type: str):
+        """Switch design type. Use 'parametric' to recover from accidental
+        direct-mode switches (equivalent to UI 'Capture Design History')."""
+        design = self._design()
+        current = design.designType
+
+        if design_type == "parametric":
+            target = adsk.fusion.DesignTypes.ParametricDesignType
+            if current == target:
+                return {"changed": False, "design_type": "parametric",
+                        "message": "Already in parametric mode"}
+            design.designType = target
+            adsk.doEvents()
+            # Verify it actually changed
+            if design.designType != target:
+                raise RuntimeError(
+                    "Failed to switch to parametric mode. "
+                    "Try 'Capture Design History' in the Fusion UI."
+                )
+            return {"changed": True, "design_type": "parametric"}
+
+        elif design_type == "direct":
+            target = adsk.fusion.DesignTypes.DirectDesignType
+            if current == target:
+                return {"changed": False, "design_type": "direct",
+                        "message": "Already in direct mode"}
+            design.designType = target
+            adsk.doEvents()
+            return {"changed": True, "design_type": "direct"}
+
+        else:
+            raise RuntimeError(
+                f"Invalid design_type '{design_type}'. "
+                f"Use 'parametric' or 'direct'."
+            )
+
+    # ------------------------------------------------------------------
     # Code execution (REPL-style)
     # ------------------------------------------------------------------
 
     def execute_code(self, code: str):
+        design = self._design()
+        type_before = design.designType
+
         ns = {
             "adsk": adsk,
             "app": self.app,
             "ui": self.ui,
-            "design": self._design(),
+            "design": design,
             "component": self._root(),
             "math": math,
         }
@@ -1955,6 +2031,18 @@ class CommandHandler:
 
         output = buf.getvalue()
         result = last_expr_value if last_expr_value is not None else output
+
+        # Warn if design type changed during execution
+        type_after = design.designType
+        design_type_warning = None
+        if type_before != type_after:
+            design_type_warning = (
+                f"WARNING: Design type changed from "
+                f"{'parametric' if type_before == 1 else 'direct'} to "
+                f"{'parametric' if type_after == 1 else 'direct'} "
+                f"during code execution. Use set_design_type to recover."
+            )
+            log.warning(design_type_warning)
         if result is not None:
             try:
                 import json as _json
@@ -1962,7 +2050,10 @@ class CommandHandler:
             except (TypeError, ValueError):
                 result = str(result)
 
-        return {"executed": True, "result": result, "output": output}
+        response = {"executed": True, "result": result, "output": output}
+        if design_type_warning:
+            response["design_type_warning"] = design_type_warning
+        return response
 
     # ------------------------------------------------------------------
     # Camera helper

--- a/src/fusion360_mcp/mock.py
+++ b/src/fusion360_mcp/mock.py
@@ -140,11 +140,22 @@ def _delete_all(_p: dict) -> dict:
 
 
 def _undo(_p: dict) -> dict:
-    return {"undone": True}
+    return {"undone": True, "design_type": 1}
 
 
 def _execute_code(p: dict) -> dict:
-    return {"code": p.get("code", ""), "result": "None"}
+    return {"executed": True, "code": p.get("code", ""), "result": "None", "output": ""}
+
+
+# ── design type safety ───────────────────────────────────────────────
+
+def _get_design_type(_p: dict) -> dict:
+    return {"design_type": "parametric", "design_type_id": 1}
+
+
+def _set_design_type(p: dict) -> dict:
+    dt = p.get("design_type", "parametric")
+    return {"changed": True, "design_type": dt}
 
 
 # ── new geometry tools ────────────────────────────────────────────────
@@ -796,4 +807,7 @@ _DISPATCH: dict[str, Any] = {
     "cam_list_setups": _cam_list_setups,
     "cam_list_operations": _cam_list_operations,
     "cam_get_operation_info": _cam_get_operation_info,
+    # design type safety
+    "get_design_type": _get_design_type,
+    "set_design_type": _set_design_type,
 }

--- a/src/fusion360_mcp/tools.py
+++ b/src/fusion360_mcp/tools.py
@@ -2041,6 +2041,39 @@ TOOLS: list[dict] = [
             "properties": {},
         },
     },
+    # ── design type safety ──────────────────────────────────────────────
+    {
+        "name": "get_design_type",
+        "title": "Get Design Type",
+        "description": (
+            "Check if the design is in parametric or direct mode. "
+            "Use this to detect accidental mode switches."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+    {
+        "name": "set_design_type",
+        "title": "Set Design Type",
+        "description": (
+            "Switch design type between 'parametric' and 'direct'. "
+            "Use 'parametric' to recover from accidental direct-mode "
+            "switches (equivalent to Capture Design History in the UI)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "required": ["design_type"],
+            "properties": {
+                "design_type": {
+                    "type": "string",
+                    "enum": ["parametric", "direct"],
+                    "description": "Target design type",
+                },
+            },
+        },
+    },
 ]
 
 # ── tool annotations ──────────────────────────────────────────────────
@@ -2054,6 +2087,7 @@ _READ_ONLY = {
     "check_interference", "ping",
     "cam_list_setups", "cam_list_operations",
     "cam_get_operation_info",
+    "get_design_type",
 }
 _DESTRUCTIVE = {"delete_all", "delete_parameter"}
 _IDEMPOTENT = {
@@ -2064,6 +2098,7 @@ _IDEMPOTENT = {
     "set_parameter", "set_appearance",
     "cam_list_setups", "cam_list_operations",
     "cam_get_operation_info",
+    "get_design_type", "set_design_type",
 }
 
 for _t in TOOLS:

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -126,6 +126,7 @@ class TestMockSceneControl:
     def test_undo(self):
         result = mock_command("undo")
         assert result["undone"] is True
+        assert "design_type" in result
 
 
 class TestMockExecuteCode:
@@ -607,6 +608,24 @@ class TestMockCAM:
         assert "strategy" in result
         assert "tool_diameter" in result
         assert "has_toolpath" in result
+
+
+class TestMockDesignTypeSafety:
+    def test_get_design_type(self):
+        result = mock_command("get_design_type")
+        assert result["design_type"] == "parametric"
+        assert result["design_type_id"] == 1
+        assert result["mode"] == "mock"
+
+    def test_set_design_type_parametric(self):
+        result = mock_command("set_design_type", {"design_type": "parametric"})
+        assert result["changed"] is True
+        assert result["design_type"] == "parametric"
+
+    def test_set_design_type_direct(self):
+        result = mock_command("set_design_type", {"design_type": "direct"})
+        assert result["changed"] is True
+        assert result["design_type"] == "direct"
 
 
 class TestMockFallback:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -95,6 +95,7 @@ class TestToolAnnotations:
             "check_interference", "ping",
             "cam_list_setups", "cam_list_operations",
             "cam_get_operation_info",
+            "get_design_type",
         }
         for t in TOOLS:
             ann = t["annotations"]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -114,6 +114,8 @@ def test_expected_tools_present():
         "cam_generate_toolpath", "cam_post_process",
         "cam_list_setups", "cam_list_operations",
         "cam_get_operation_info",
+        # design type safety
+        "get_design_type", "set_design_type",
     }
     missing = expected - names
     assert not missing, f"Missing tools: {missing}"


### PR DESCRIPTION
## Summary
- New tools: `get_design_type` / `set_design_type` — inspect and switch between parametric and direct modes
- `undo` now guards against accidental Parametric→Direct mode switches (checks design type before/after, auto-redoes if it would switch modes)
- `execute_code` warns if design type changes during execution

## Why
Accidental Parametric→Direct switches break BaseFeature modeling. This catches the common case where `undo` peels back past the mode-change boundary.

## Test plan
- [x] `uv run pytest -q` — 250 passed
- [ ] Manual verification in Fusion 360 against a parametric design

🤖 Generated with [Claude Code](https://claude.com/claude-code)