### PR TITLE
Agent-feedback envelope: structured errors, deltas, render_view

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,7 @@
 
 An MCP server that bridges Claude Code to Autodesk Fusion 360 for CAD automation. Two components:
 
-1. **This repo** — Python MCP server (stdio transport, 80 tools). Claude talks to this.
+1. **This repo** — Python MCP server (stdio transport, 81 tools). Claude talks to this.
 2. **Fusion360MCP add-in** — installed in Fusion's AddIns folder. Listens on `localhost:9876`.
 
 The MCP server receives tool calls from Claude, forwards them as JSON over TCP to the add-in, and returns results.
@@ -19,7 +19,7 @@ Claude Code ←(stdio MCP)→ This Server ←(TCP :9876)→ Fusion360MCP Add-in 
 
 ```bash
 uv sync --dev      # install deps
-uv run pytest -v   # run tests (245 tests)
+uv run pytest -v   # run tests (275 tests)
 uv run ruff check  # lint
 ```
 
@@ -27,9 +27,10 @@ uv run ruff check  # lint
 
 - `src/fusion360_mcp/server.py` — MCP server entry point (click CLI), resources, prompts
 - `src/fusion360_mcp/connection.py` — TCP client to Fusion add-in
-- `src/fusion360_mcp/tools.py` — 80 tool definitions with annotations
+- `src/fusion360_mcp/tools.py` — 81 tool definitions with annotations
+- `src/fusion360_mcp/hints.py` — error-classification table (mirror of `addon/server/hints.py`)
 - `src/fusion360_mcp/mock.py` — mock responses for `--mode mock` testing
-- `tests/` — 245 tests covering tools, mock handlers, server routing, connection, annotations
+- `tests/` — 275 tests covering tools, mock handlers, server routing, connection, annotations
 
 ## Adding a new command
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This is an MCP server (80 tools) that connects AI coding agents to Autodesk Fusion 360 for CAD automation. It consists of two pieces:
+This is an MCP server (81 tools) that connects AI coding agents to Autodesk Fusion 360 for CAD automation. It consists of two pieces:
 
 1. **MCP Server** (this repo) — speaks MCP protocol over stdio, forwards commands to Fusion via TCP
 2. **Fusion 360 Add-in** — runs inside Fusion, executes commands on the main thread via CustomEvent bridge
@@ -154,13 +154,58 @@ The add-in uses a CustomEvent + work queue pattern to safely dispatch all Fusion
 |------|-------------|
 | `execute_code` | Run arbitrary Python in Fusion (REPL-style) |
 
+### Perception
+| Tool | Description |
+|------|-------------|
+| `render_view` | Capture the active viewport as a PNG. Pass `view=iso\|front\|top\|...` to reposition the camera first. Returns an image content block you can visually inspect to validate geometry before committing to more operations. |
+
+## Response shape
+
+Every tool call returns a dict-shaped result with these conventions — read them instead of guessing whether an operation worked:
+
+**Success:**
+```json
+{
+  "ok": true,
+  "body_name": "Body1",   // tool-specific fields
+  ...,
+  "deltas": {             // present only for mutations
+    "body_count_before": 0,
+    "body_count_after":  1,
+    "body_count_delta":  1,
+    "mass_g_before": 0.0,
+    "mass_g_after":  7.85,
+    "mass_g_delta":  7.85,
+    "bbox_before": null,
+    "bbox_after":  {"min": [0,0,0], "max": [1,1,1]}
+  }
+}
+```
+
+**Failure (no exception — the error flows back as data):**
+```json
+{
+  "ok": false,
+  "error_kind":    "PROFILE_NOT_CLOSED",     // stable tag you can branch on
+  "error_message": "No profiles in sketch",  // short human-readable
+  "hints":  ["close the loop", "..."],        // contextual repair suggestions
+  "traceback": "..."                         // full traceback for debugging
+}
+```
+
+Known `error_kind` values: `PROFILE_NOT_CLOSED`, `SKETCH_NOT_FOUND`, `BODY_NOT_FOUND`, `SELF_INTERSECTION`, `REGEN_FAILED`, `BOOLEAN_NO_OP`, `INVALID_INPUT`, `NO_ACTIVE_DESIGN`, `DESIGN_TYPE_MISMATCH`, `TIMEOUT`, `UNKNOWN_COMMAND`, `UNKNOWN`.
+
+**Use the deltas to sanity-check without a render.** A `boolean_operation` that reports `body_count_delta: 0, mass_g_delta: 0` did nothing — follow up with `check_interference` before retrying. An `extrude` that shifts mass by three orders of magnitude is probably using the wrong units.
+
+**Use `render_view` sparingly** — it returns ~200KB–2MB of base64 image data. Render after a logical checkpoint (finished a feature, about to commit), not after every mutation. Deltas already tell you whether the feature *did* something; `render_view` tells you whether it did the *right* something.
+
 ## MCP protocol features
 
 - **Tool annotations** — every tool is tagged `readOnlyHint`, `destructiveHint`, `idempotentHint` so clients can auto-approve safe operations
 - **Resources** — `fusion360://status`, `fusion360://design`, `fusion360://parameters`
 - **Resource templates** — `fusion360://body/{name}`, `fusion360://component/{name}`
 - **Prompts** — `create-box`, `model-threaded-bolt`, `sheet-metal-enclosure` workflow templates
-- **Structured errors** — `isError=True` when the add-in reports failures
+- **Structured errors** — `isError=True` when the add-in reports failures. Error results carry `error_kind`, `hints`, and a traceback so the agent can branch on failure mode rather than parsing prose (see _Response shape_ above).
 - **Mock mode** — `--mode mock` returns test data without Fusion running
 
 ## Important constraints

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Call the `ping` tool from your client. If it returns `{"pong": true}`, everythin
 2. Stop the add-in in Fusion (Shift+S → Add-Ins → Fusion360MCP → Stop)
 3. Delete the add-in folder from Fusion's AddIns directory
 
-## Available Tools (80)
+## Available Tools (81)
 
 ### Scene & Query
 | Tool | Description |

--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -7,9 +7,11 @@ is safe.
 """
 
 import ast
+import base64
 import io
 import math
 import os
+import tempfile
 import time
 import traceback
 from contextlib import redirect_stdout
@@ -19,6 +21,7 @@ import adsk.core
 import adsk.fusion
 
 from . import get_logger
+from . import hints as _hints
 
 log = get_logger("handler")
 
@@ -36,108 +39,161 @@ class CommandHandler:
 
     _COMMANDS = None  # populated lazily
 
+    # Commands that can change body mass / bbox / body count.  Only these
+    # get before/after snapshots so agents can sanity-check without a render.
+    _MUTATION_COMMANDS = frozenset(
+        {
+            # feature ops
+            "extrude",
+            "revolve",
+            "sweep",
+            "loft",
+            "fillet",
+            "chamfer",
+            "shell",
+            "mirror",
+            "create_hole",
+            "rectangular_pattern",
+            "circular_pattern",
+            "create_thread",
+            "draft_faces",
+            "split_body",
+            "split_face",
+            "offset_faces",
+            "scale_body",
+            "suppress_feature",
+            "unsuppress_feature",
+            # body ops
+            "move_body",
+            "boolean_operation",
+            # primitives
+            "create_box",
+            "create_cylinder",
+            "create_sphere",
+            "create_torus",
+            # surface / sheet metal (can produce / thicken bodies)
+            "thicken_surface",
+            "patch_surface",
+            "stitch_surfaces",
+            "ruled_surface",
+            "trim_surface",
+            "create_flange",
+            "create_bend",
+            "flat_pattern",
+            "unfold",
+            # scene-wide
+            "delete_all",
+            "undo",
+            # parametric & agent-authored changes
+            "set_parameter",
+            "execute_code",
+        }
+    )
+
     def execute_command(self, command: dict) -> dict:
         """Route *command* to the correct handler; return a response dict."""
         if self._COMMANDS is None:
             self.__class__._COMMANDS = {
                 # scene / query
-                "get_scene_info":       self.get_scene_info,
-                "get_object_info":      self.get_object_info,
-                "list_components":      self.list_components,
+                "get_scene_info": self.get_scene_info,
+                "get_object_info": self.get_object_info,
+                "list_components": self.list_components,
                 # sketch
-                "create_sketch":        self.create_sketch,
-                "draw_rectangle":       self.draw_rectangle,
-                "draw_circle":          self.draw_circle,
-                "draw_line":            self.draw_line,
-                "draw_arc":             self.draw_arc,
-                "draw_spline":          self.draw_spline,
-                "create_polygon":       self.create_polygon,
-                "add_constraint":       self.add_constraint,
-                "add_dimension":        self.add_dimension,
-                "offset_curve":         self.offset_curve,
-                "trim_curve":           self.trim_curve,
-                "extend_curve":         self.extend_curve,
-                "project_geometry":     self.project_geometry,
+                "create_sketch": self.create_sketch,
+                "draw_rectangle": self.draw_rectangle,
+                "draw_circle": self.draw_circle,
+                "draw_line": self.draw_line,
+                "draw_arc": self.draw_arc,
+                "draw_spline": self.draw_spline,
+                "create_polygon": self.create_polygon,
+                "add_constraint": self.add_constraint,
+                "add_dimension": self.add_dimension,
+                "offset_curve": self.offset_curve,
+                "trim_curve": self.trim_curve,
+                "extend_curve": self.extend_curve,
+                "project_geometry": self.project_geometry,
                 # features
-                "extrude":              self.extrude,
-                "revolve":              self.revolve,
-                "sweep":                self.sweep,
-                "loft":                 self.loft,
-                "fillet":               self.fillet,
-                "chamfer":              self.chamfer,
-                "shell":                self.shell,
-                "mirror":               self.mirror,
-                "create_hole":          self.create_hole,
-                "rectangular_pattern":  self.rectangular_pattern,
-                "circular_pattern":     self.circular_pattern,
-                "create_thread":        self.create_thread,
-                "draft_faces":          self.draft_faces,
-                "split_body":           self.split_body,
-                "split_face":           self.split_face,
-                "offset_faces":         self.offset_faces,
-                "scale_body":           self.scale_body,
-                "suppress_feature":     self.suppress_feature,
-                "unsuppress_feature":   self.unsuppress_feature,
+                "extrude": self.extrude,
+                "revolve": self.revolve,
+                "sweep": self.sweep,
+                "loft": self.loft,
+                "fillet": self.fillet,
+                "chamfer": self.chamfer,
+                "shell": self.shell,
+                "mirror": self.mirror,
+                "create_hole": self.create_hole,
+                "rectangular_pattern": self.rectangular_pattern,
+                "circular_pattern": self.circular_pattern,
+                "create_thread": self.create_thread,
+                "draft_faces": self.draft_faces,
+                "split_body": self.split_body,
+                "split_face": self.split_face,
+                "offset_faces": self.offset_faces,
+                "scale_body": self.scale_body,
+                "suppress_feature": self.suppress_feature,
+                "unsuppress_feature": self.unsuppress_feature,
                 # body operations
-                "move_body":            self.move_body,
-                "export_stl":           self.export_stl,
-                "export_step":          self.export_step,
-                "export_f3d":           self.export_f3d,
-                "boolean_operation":    self.boolean_operation,
-                "delete_all":           self.delete_all,
-                "undo":                 self.undo,
+                "move_body": self.move_body,
+                "export_stl": self.export_stl,
+                "export_step": self.export_step,
+                "export_f3d": self.export_f3d,
+                "boolean_operation": self.boolean_operation,
+                "delete_all": self.delete_all,
+                "undo": self.undo,
                 # direct primitives
-                "create_box":           self.create_box,
-                "create_cylinder":      self.create_cylinder,
-                "create_sphere":        self.create_sphere,
-                "create_torus":         self.create_torus,
+                "create_box": self.create_box,
+                "create_cylinder": self.create_cylinder,
+                "create_sphere": self.create_sphere,
+                "create_torus": self.create_torus,
                 # construction geometry
                 "create_construction_plane": self.create_construction_plane,
-                "create_construction_axis":  self.create_construction_axis,
+                "create_construction_axis": self.create_construction_axis,
                 # assembly
-                "create_component":     self.create_component,
-                "add_joint":            self.add_joint,
+                "create_component": self.create_component,
+                "add_joint": self.add_joint,
                 "create_as_built_joint": self.create_as_built_joint,
-                "create_rigid_group":   self.create_rigid_group,
+                "create_rigid_group": self.create_rigid_group,
                 # inspection / analysis
-                "measure_distance":     self.measure_distance,
-                "measure_angle":        self.measure_angle,
+                "measure_distance": self.measure_distance,
+                "measure_angle": self.measure_angle,
                 "get_physical_properties": self.get_physical_properties,
                 "create_section_analysis": self.create_section_analysis,
-                "check_interference":   self.check_interference,
+                "check_interference": self.check_interference,
                 # appearance
-                "set_appearance":       self.set_appearance,
+                "set_appearance": self.set_appearance,
                 # parameters
-                "get_parameters":       self.get_parameters,
-                "create_parameter":     self.create_parameter,
-                "set_parameter":        self.set_parameter,
-                "delete_parameter":     self.delete_parameter,
+                "get_parameters": self.get_parameters,
+                "create_parameter": self.create_parameter,
+                "set_parameter": self.set_parameter,
+                "delete_parameter": self.delete_parameter,
                 # surface operations
-                "patch_surface":        self.patch_surface,
-                "stitch_surfaces":      self.stitch_surfaces,
-                "thicken_surface":      self.thicken_surface,
-                "ruled_surface":        self.ruled_surface,
-                "trim_surface":         self.trim_surface,
+                "patch_surface": self.patch_surface,
+                "stitch_surfaces": self.stitch_surfaces,
+                "thicken_surface": self.thicken_surface,
+                "ruled_surface": self.ruled_surface,
+                "trim_surface": self.trim_surface,
                 # sheet metal
-                "create_flange":        self.create_flange,
-                "create_bend":          self.create_bend,
-                "flat_pattern":         self.flat_pattern,
-                "unfold":               self.unfold,
+                "create_flange": self.create_flange,
+                "create_bend": self.create_bend,
+                "flat_pattern": self.flat_pattern,
+                "unfold": self.unfold,
                 # code execution
-                "execute_code":         self.execute_code,
+                "execute_code": self.execute_code,
                 # CAM
-                "cam_list_setups":      self.cam_list_setups,
-                "cam_list_operations":  self.cam_list_operations,
+                "cam_list_setups": self.cam_list_setups,
+                "cam_list_operations": self.cam_list_operations,
                 "cam_get_operation_info": self.cam_get_operation_info,
-                "cam_create_setup":     self.cam_create_setup,
+                "cam_create_setup": self.cam_create_setup,
                 "cam_create_operation": self.cam_create_operation,
                 "cam_generate_toolpath": self.cam_generate_toolpath,
-                "cam_post_process":     self.cam_post_process,
+                "cam_post_process": self.cam_post_process,
                 # health
-                "ping":                 self.ping,
+                "ping": self.ping,
                 # design type safety
-                "get_design_type":      self.get_design_type,
-                "set_design_type":      self.set_design_type,
+                "get_design_type": self.get_design_type,
+                "set_design_type": self.set_design_type,
+                # perception
+                "render_view": self.render_view,
             }
 
         cmd_type = command.get("type")
@@ -145,18 +201,42 @@ class CommandHandler:
 
         handler = self._COMMANDS.get(cmd_type)
         if handler is None:
-            return {"status": "error",
-                    "message": f"Unknown command: {cmd_type}"}
+            # Infrastructure-level failure (not an application error) —
+            # keep the legacy error envelope so the client raises.
+            return {"status": "error", "message": f"Unknown command: {cmd_type}"}
+
+        is_mutation = cmd_type in self._MUTATION_COMMANDS
+        snap_before = self._snapshot() if is_mutation else None
+
         try:
             t0 = time.monotonic()
             result = handler(**params)
             elapsed = time.monotonic() - t0
             log.debug("%s completed in %.3fs", cmd_type, elapsed)
-            return {"status": "success", "result": result}
         except Exception as exc:
             log.error("%s raised: %s", cmd_type, exc)
-            return {"status": "error",
-                    "message": f"{exc}\n{traceback.format_exc()}"}
+            error_kind, hint_list = _hints.classify(exc)
+            return {
+                "status": "success",
+                "result": {
+                    "ok": False,
+                    "error_kind": error_kind,
+                    "error_message": str(exc) or exc.__class__.__name__,
+                    "hints": hint_list,
+                    "traceback": traceback.format_exc(),
+                },
+            }
+
+        if not isinstance(result, dict):
+            result = {"value": result}
+        result.setdefault("ok", True)
+
+        if is_mutation and snap_before is not None:
+            snap_after = self._snapshot()
+            if snap_after is not None:
+                result["deltas"] = self._compute_deltas(snap_before, snap_after)
+
+        return {"status": "success", "result": result}
 
     # ------------------------------------------------------------------
     # Helpers
@@ -229,15 +309,16 @@ class CommandHandler:
     @staticmethod
     def _operation_type(name: str):
         m = {
-            "new_body":   adsk.fusion.FeatureOperations.NewBodyFeatureOperation,
-            "join":       adsk.fusion.FeatureOperations.JoinFeatureOperation,
-            "cut":        adsk.fusion.FeatureOperations.CutFeatureOperation,
-            "intersect":  adsk.fusion.FeatureOperations.IntersectFeatureOperation,
+            "new_body": adsk.fusion.FeatureOperations.NewBodyFeatureOperation,
+            "join": adsk.fusion.FeatureOperations.JoinFeatureOperation,
+            "cut": adsk.fusion.FeatureOperations.CutFeatureOperation,
+            "intersect": adsk.fusion.FeatureOperations.IntersectFeatureOperation,
         }
         t = m.get(name)
         if t is None:
             raise RuntimeError(
-                f"Unknown operation '{name}' — use new_body/join/cut/intersect")
+                f"Unknown operation '{name}' — use new_body/join/cut/intersect"
+            )
         return t
 
     def _select_edges(self, body, selection: str):
@@ -268,8 +349,8 @@ class CommandHandler:
                     coll.add(edge)
         else:
             raise RuntimeError(
-                f"Unknown edge_selection '{selection}' "
-                "— use all/top/bottom/vertical")
+                f"Unknown edge_selection '{selection}' — use all/top/bottom/vertical"
+            )
 
         if coll.count == 0:
             raise RuntimeError(f"No edges matched selection '{selection}'")
@@ -297,16 +378,15 @@ class CommandHandler:
             for face in body.faces:
                 # Check if face normal is roughly horizontal (vertical face)
                 try:
-                    _, normal_vec = face.evaluator.getNormalAtPoint(
-                        face.pointOnFace)
+                    _, normal_vec = face.evaluator.getNormalAtPoint(face.pointOnFace)
                     if abs(normal_vec.z) < 0.1:
                         coll.add(face)
                 except Exception:
                     pass
         else:
             raise RuntimeError(
-                f"Unknown face_selection '{selection}' "
-                "— use all/top/bottom/vertical")
+                f"Unknown face_selection '{selection}' — use all/top/bottom/vertical"
+            )
 
         if coll.count == 0:
             raise RuntimeError(f"No faces matched selection '{selection}'")
@@ -323,22 +403,26 @@ class CommandHandler:
         bodies = []
         for i in range(root.bRepBodies.count):
             b = root.bRepBodies.item(i)
-            bodies.append({
-                "name": b.name,
-                "volume": b.volume,
-                "area": b.area,
-                "material": b.material.name if b.material else None,
-                "is_visible": b.isVisible,
-            })
+            bodies.append(
+                {
+                    "name": b.name,
+                    "volume": b.volume,
+                    "area": b.area,
+                    "material": b.material.name if b.material else None,
+                    "is_visible": b.isVisible,
+                }
+            )
 
         sketches = []
         for i in range(root.sketches.count):
             s = root.sketches.item(i)
-            sketches.append({
-                "name": s.name,
-                "profile_count": s.profiles.count,
-                "is_visible": s.isVisible,
-            })
+            sketches.append(
+                {
+                    "name": s.name,
+                    "profile_count": s.profiles.count,
+                    "is_visible": s.isVisible,
+                }
+            )
 
         return {
             "design_name": design.parentDocument.name,
@@ -348,8 +432,9 @@ class CommandHandler:
             "bodies_count": root.bRepBodies.count,
             "sketches_count": root.sketches.count,
             "features_count": root.features.count,
-            "timeline_count": (design.timeline.count
-                               if hasattr(design, "timeline") else 0),
+            "timeline_count": (
+                design.timeline.count if hasattr(design, "timeline") else 0
+            ),
             "camera": self._camera_info(),
         }
 
@@ -361,8 +446,11 @@ class CommandHandler:
             b = root.bRepBodies.item(i)
             if b.name == name:
                 return {
-                    "found": True, "type": "body", "name": name,
-                    "volume": b.volume, "area": b.area,
+                    "found": True,
+                    "type": "body",
+                    "name": name,
+                    "volume": b.volume,
+                    "area": b.area,
                     "material": b.material.name if b.material else None,
                     "is_visible": b.isVisible,
                     "faces_count": b.faces.count,
@@ -376,7 +464,9 @@ class CommandHandler:
             s = root.sketches.item(i)
             if s.name == name:
                 return {
-                    "found": True, "type": "sketch", "name": name,
+                    "found": True,
+                    "type": "sketch",
+                    "name": name,
                     "is_visible": s.isVisible,
                     "profile_count": s.profiles.count,
                     "curve_count": s.sketchCurves.count,
@@ -388,11 +478,13 @@ class CommandHandler:
         root = self._root()
         components = [{"name": root.name, "is_root": True}]
         for occ in root.allOccurrences:
-            components.append({
-                "name": occ.component.name,
-                "is_root": False,
-                "is_visible": occ.isVisible,
-            })
+            components.append(
+                {
+                    "name": occ.component.name,
+                    "is_root": False,
+                    "is_visible": occ.isVisible,
+                }
+            )
         return {"components": components, "count": len(components)}
 
     # ------------------------------------------------------------------
@@ -413,48 +505,72 @@ class CommandHandler:
         else:
             sketch = root.sketches.add(self._construction_plane(plane))
 
-        return {"sketch_name": sketch.name, "plane": plane,
-                "z_offset": z_offset}
+        return {"sketch_name": sketch.name, "plane": plane, "z_offset": z_offset}
 
-    def draw_rectangle(self, width: float, height: float,
-                       origin_x: float = 0, origin_y: float = 0,
-                       origin_z: float = 0):
+    def draw_rectangle(
+        self,
+        width: float,
+        height: float,
+        origin_x: float = 0,
+        origin_y: float = 0,
+        origin_z: float = 0,
+    ):
         sketch = self._last_sketch()
         p1 = adsk.core.Point3D.create(origin_x, origin_y, origin_z)
-        p2 = adsk.core.Point3D.create(origin_x + width,
-                                       origin_y + height, origin_z)
+        p2 = adsk.core.Point3D.create(origin_x + width, origin_y + height, origin_z)
         sketch.sketchCurves.sketchLines.addTwoPointRectangle(p1, p2)
         return {"sketch": sketch.name, "width": width, "height": height}
 
-    def draw_circle(self, radius: float,
-                    center_x: float = 0, center_y: float = 0,
-                    center_z: float = 0):
+    def draw_circle(
+        self,
+        radius: float,
+        center_x: float = 0,
+        center_y: float = 0,
+        center_z: float = 0,
+    ):
         sketch = self._last_sketch()
         c = adsk.core.Point3D.create(center_x, center_y, center_z)
         sketch.sketchCurves.sketchCircles.addByCenterRadius(c, radius)
-        return {"sketch": sketch.name, "radius": radius,
-                "center": [center_x, center_y, center_z]}
+        return {
+            "sketch": sketch.name,
+            "radius": radius,
+            "center": [center_x, center_y, center_z],
+        }
 
-    def draw_line(self, start_x: float, start_y: float,
-                  end_x: float, end_y: float,
-                  start_z: float = 0, end_z: float = 0):
+    def draw_line(
+        self,
+        start_x: float,
+        start_y: float,
+        end_x: float,
+        end_y: float,
+        start_z: float = 0,
+        end_z: float = 0,
+    ):
         sketch = self._last_sketch()
         sp = adsk.core.Point3D.create(start_x, start_y, start_z)
         ep = adsk.core.Point3D.create(end_x, end_y, end_z)
         sketch.sketchCurves.sketchLines.addByTwoPoints(sp, ep)
-        return {"sketch": sketch.name,
-                "start": [start_x, start_y, start_z],
-                "end": [end_x, end_y, end_z]}
+        return {
+            "sketch": sketch.name,
+            "start": [start_x, start_y, start_z],
+            "end": [end_x, end_y, end_z],
+        }
 
-    def draw_arc(self, center_x: float, center_y: float,
-                 start_x: float, start_y: float, sweep_angle: float,
-                 center_z: float = 0, start_z: float = 0):
+    def draw_arc(
+        self,
+        center_x: float,
+        center_y: float,
+        start_x: float,
+        start_y: float,
+        sweep_angle: float,
+        center_z: float = 0,
+        start_z: float = 0,
+    ):
         sketch = self._last_sketch()
         center = adsk.core.Point3D.create(center_x, center_y, center_z)
         start = adsk.core.Point3D.create(start_x, start_y, start_z)
         sweep_rad = math.radians(sweep_angle)
-        sketch.sketchCurves.sketchArcs.addByCenterStartSweep(
-            center, start, sweep_rad)
+        sketch.sketchCurves.sketchArcs.addByCenterStartSweep(center, start, sweep_rad)
         return {"sketch": sketch.name, "sweep_angle": sweep_angle}
 
     def draw_spline(self, spline_type: str, points: list, degree: int = 3):
@@ -468,12 +584,20 @@ class CommandHandler:
             sketch.sketchCurves.sketchFittedSplines.add(pts)
         else:  # control_points
             sketch.sketchCurves.sketchControlPointSplines.add(pts, degree)
-        return {"sketch": sketch.name, "spline_type": spline_type,
-                "points_count": len(points)}
+        return {
+            "sketch": sketch.name,
+            "spline_type": spline_type,
+            "points_count": len(points),
+        }
 
-    def create_polygon(self, sides: int, radius: float,
-                       center_x: float = 0, center_y: float = 0,
-                       center_z: float = 0):
+    def create_polygon(
+        self,
+        sides: int,
+        radius: float,
+        center_x: float = 0,
+        center_y: float = 0,
+        center_z: float = 0,
+    ):
         sketch = self._last_sketch()
         # Draw inscribed polygon
         for i in range(sides):
@@ -482,19 +606,27 @@ class CommandHandler:
             p1 = adsk.core.Point3D.create(
                 center_x + radius * math.cos(angle1),
                 center_y + radius * math.sin(angle1),
-                center_z)
+                center_z,
+            )
             p2 = adsk.core.Point3D.create(
                 center_x + radius * math.cos(angle2),
                 center_y + radius * math.sin(angle2),
-                center_z)
+                center_z,
+            )
             sketch.sketchCurves.sketchLines.addByTwoPoints(p1, p2)
         return {"sketch": sketch.name, "sides": sides, "radius": radius}
 
-    def add_constraint(self, constraint_type: str,
-                       entity_one: int = None, entity_two: int = None,
-                       symmetry_line: int = None, sketch_name: str = None):
-        sketch = (self._sketch_by_name(sketch_name) if sketch_name
-                  else self._last_sketch())
+    def add_constraint(
+        self,
+        constraint_type: str,
+        entity_one: int = None,
+        entity_two: int = None,
+        symmetry_line: int = None,
+        sketch_name: str = None,
+    ):
+        sketch = (
+            self._sketch_by_name(sketch_name) if sketch_name else self._last_sketch()
+        )
         constraints = sketch.geometricConstraints
         curves = list(sketch.sketchCurves)
 
@@ -514,9 +646,9 @@ class CommandHandler:
             "collinear": lambda: constraints.addCollinear(e1, e2),
             "smooth": lambda: constraints.addSmooth(e1, e2),
             "midpoint": lambda: constraints.addMidPoint(
-                sketch.sketchPoints.item(entity_one), e2),
-            "symmetry": lambda: constraints.addSymmetry(
-                e1, e2, curves[symmetry_line]),
+                sketch.sketchPoints.item(entity_one), e2
+            ),
+            "symmetry": lambda: constraints.addSymmetry(e1, e2, curves[symmetry_line]),
         }
 
         if constraint_type not in constraint_map:
@@ -525,11 +657,17 @@ class CommandHandler:
         constraint_map[constraint_type]()
         return {"sketch": sketch.name, "constraint_type": constraint_type}
 
-    def add_dimension(self, dimension_type: str, value: float,
-                      entity_one: int = None, entity_two: int = None,
-                      sketch_name: str = None):
-        sketch = (self._sketch_by_name(sketch_name) if sketch_name
-                  else self._last_sketch())
+    def add_dimension(
+        self,
+        dimension_type: str,
+        value: float,
+        entity_one: int = None,
+        entity_two: int = None,
+        sketch_name: str = None,
+    ):
+        sketch = (
+            self._sketch_by_name(sketch_name) if sketch_name else self._last_sketch()
+        )
         dims = sketch.sketchDimensions
         curves = list(sketch.sketchCurves)
 
@@ -539,19 +677,25 @@ class CommandHandler:
 
         if dimension_type == "distance":
             dim = dims.addDistanceDimension(
-                e1.startSketchPoint, e2.startSketchPoint,
+                e1.startSketchPoint,
+                e2.startSketchPoint,
                 adsk.fusion.DimensionOrientations.AlignedDimensionOrientation,
-                text_pt)
+                text_pt,
+            )
         elif dimension_type == "horizontal":
             dim = dims.addDistanceDimension(
-                e1.startSketchPoint, e2.startSketchPoint,
+                e1.startSketchPoint,
+                e2.startSketchPoint,
                 adsk.fusion.DimensionOrientations.HorizontalDimensionOrientation,
-                text_pt)
+                text_pt,
+            )
         elif dimension_type == "vertical":
             dim = dims.addDistanceDimension(
-                e1.startSketchPoint, e2.startSketchPoint,
+                e1.startSketchPoint,
+                e2.startSketchPoint,
                 adsk.fusion.DimensionOrientations.VerticalDimensionOrientation,
-                text_pt)
+                text_pt,
+            )
         elif dimension_type == "angular":
             dim = dims.addAngularDimension(e1, e2, text_pt)
         elif dimension_type == "radial":
@@ -562,14 +706,19 @@ class CommandHandler:
             raise RuntimeError(f"Unknown dimension type: {dimension_type}")
 
         dim.parameter.value = value
-        return {"sketch": sketch.name, "dimension_type": dimension_type,
-                "value": value}
+        return {"sketch": sketch.name, "dimension_type": dimension_type, "value": value}
 
-    def offset_curve(self, curve_index: int, offset_distance: float,
-                     direction_x: float = 1, direction_y: float = 0,
-                     sketch_name: str = None):
-        sketch = (self._sketch_by_name(sketch_name) if sketch_name
-                  else self._last_sketch())
+    def offset_curve(
+        self,
+        curve_index: int,
+        offset_distance: float,
+        direction_x: float = 1,
+        direction_y: float = 0,
+        sketch_name: str = None,
+    ):
+        sketch = (
+            self._sketch_by_name(sketch_name) if sketch_name else self._last_sketch()
+        )
         curves = list(sketch.sketchCurves)
         curve = curves[curve_index]
         direction_pt = adsk.core.Point3D.create(direction_x, direction_y, 0)
@@ -579,30 +728,36 @@ class CommandHandler:
         sketch.offset(coll, direction_pt, offset_distance)
         return {"sketch": sketch.name, "offset_distance": offset_distance}
 
-    def trim_curve(self, curve_index: int, point_x: float, point_y: float,
-                   sketch_name: str = None):
-        sketch = (self._sketch_by_name(sketch_name) if sketch_name
-                  else self._last_sketch())
+    def trim_curve(
+        self, curve_index: int, point_x: float, point_y: float, sketch_name: str = None
+    ):
+        sketch = (
+            self._sketch_by_name(sketch_name) if sketch_name else self._last_sketch()
+        )
         curves = list(sketch.sketchCurves)
         curve = curves[curve_index]
         point = adsk.core.Point3D.create(point_x, point_y, 0)
         curve.trim(point)
         return {"sketch": sketch.name, "trimmed": True}
 
-    def extend_curve(self, curve_index: int, point_x: float, point_y: float,
-                     sketch_name: str = None):
-        sketch = (self._sketch_by_name(sketch_name) if sketch_name
-                  else self._last_sketch())
+    def extend_curve(
+        self, curve_index: int, point_x: float, point_y: float, sketch_name: str = None
+    ):
+        sketch = (
+            self._sketch_by_name(sketch_name) if sketch_name else self._last_sketch()
+        )
         curves = list(sketch.sketchCurves)
         curve = curves[curve_index]
         point = adsk.core.Point3D.create(point_x, point_y, 0)
         curve.extend(point)
         return {"sketch": sketch.name, "extended": True}
 
-    def project_geometry(self, source_name: str, is_linked: bool = True,
-                         sketch_name: str = None):
-        sketch = (self._sketch_by_name(sketch_name) if sketch_name
-                  else self._last_sketch())
+    def project_geometry(
+        self, source_name: str, is_linked: bool = True, sketch_name: str = None
+    ):
+        sketch = (
+            self._sketch_by_name(sketch_name) if sketch_name else self._last_sketch()
+        )
         body = self._body_by_name(source_name)
 
         projected = []
@@ -610,15 +765,23 @@ class CommandHandler:
             proj = sketch.project(edge)
             projected.append(proj.count)
 
-        return {"sketch": sketch.name, "source": source_name,
-                "projected_curves": sum(projected)}
+        return {
+            "sketch": sketch.name,
+            "source": source_name,
+            "projected_curves": sum(projected),
+        }
 
     # ------------------------------------------------------------------
     # Features
     # ------------------------------------------------------------------
 
-    def extrude(self, height: float, profile_index: int = 0,
-                operation: str = "new_body", direction: str = "positive"):
+    def extrude(
+        self,
+        height: float,
+        profile_index: int = 0,
+        operation: str = "new_body",
+        direction: str = "positive",
+    ):
         root = self._root()
         sketch = self._last_sketch()
         if sketch.profiles.count == 0:
@@ -626,8 +789,7 @@ class CommandHandler:
         profile = sketch.profiles.item(profile_index)
 
         ext_feats = root.features.extrudeFeatures
-        ext_input = ext_feats.createInput(profile,
-                                          self._operation_type(operation))
+        ext_input = ext_feats.createInput(profile, self._operation_type(operation))
         dist = adsk.core.ValueInput.createByReal(height)
         if direction == "symmetric":
             ext_input.setSymmetricExtent(dist, True)
@@ -635,15 +797,25 @@ class CommandHandler:
             ext_input.setDistanceExtent(direction == "negative", dist)
 
         feat = ext_feats.add(ext_input)
-        return {"feature_name": feat.name, "height": height,
-                "operation": operation, "direction": direction}
+        return {
+            "feature_name": feat.name,
+            "height": height,
+            "operation": operation,
+            "direction": direction,
+        }
 
-    def revolve(self, angle: float, profile_index: int = 0,
-                axis_origin_x: float = 0, axis_origin_y: float = 0,
-                axis_origin_z: float = 0,
-                axis_direction_x: float = 1, axis_direction_y: float = 0,
-                axis_direction_z: float = 0,
-                operation: str = "new_body"):
+    def revolve(
+        self,
+        angle: float,
+        profile_index: int = 0,
+        axis_origin_x: float = 0,
+        axis_origin_y: float = 0,
+        axis_origin_z: float = 0,
+        axis_direction_x: float = 1,
+        axis_direction_y: float = 0,
+        axis_direction_z: float = 0,
+        operation: str = "new_body",
+    ):
         root = self._root()
         sketch = self._last_sketch()
         if sketch.profiles.count == 0:
@@ -664,28 +836,35 @@ class CommandHandler:
         else:
             # Create construction line in sketch
             origin = adsk.core.Point3D.create(
-                axis_origin_x, axis_origin_y, axis_origin_z)
+                axis_origin_x, axis_origin_y, axis_origin_z
+            )
             end_pt = adsk.core.Point3D.create(
                 axis_origin_x + axis_direction_x * 10,
                 axis_origin_y + axis_direction_y * 10,
-                axis_origin_z + axis_direction_z * 10)
+                axis_origin_z + axis_direction_z * 10,
+            )
             line = sketch.sketchCurves.sketchLines.addByTwoPoints(origin, end_pt)
             line.isConstruction = True
             axis_entity = line
 
         rev_feats = root.features.revolveFeatures
-        rev_input = rev_feats.createInput(profile, axis_entity,
-                                          self._operation_type(operation))
+        rev_input = rev_feats.createInput(
+            profile, axis_entity, self._operation_type(operation)
+        )
 
         angle_val = adsk.core.ValueInput.createByString(f"{angle} deg")
         rev_input.setAngleExtent(False, angle_val)
 
         feat = rev_feats.add(rev_input)
-        return {"feature_name": feat.name, "angle": angle,
-                "operation": operation}
+        return {"feature_name": feat.name, "angle": angle, "operation": operation}
 
-    def sweep(self, profile_index: int, path_sketch_name: str,
-              path_curve_index: int = 0, operation: str = "new_body"):
+    def sweep(
+        self,
+        profile_index: int,
+        path_sketch_name: str,
+        path_curve_index: int = 0,
+        operation: str = "new_body",
+    ):
         root = self._root()
         sketch = self._last_sketch()
         path_sketch = self._sketch_by_name(path_sketch_name)
@@ -700,8 +879,9 @@ class CommandHandler:
         path = root.features.createPath(path_curve)
 
         sweep_feats = root.features.sweepFeatures
-        sweep_input = sweep_feats.createInput(profile, path,
-                                              self._operation_type(operation))
+        sweep_input = sweep_feats.createInput(
+            profile, path, self._operation_type(operation)
+        )
         feat = sweep_feats.add(sweep_input)
         return {"feature_name": feat.name, "operation": operation}
 
@@ -717,44 +897,73 @@ class CommandHandler:
             loft_input.loftSections.add(sketch.profiles.item(0))
 
         feat = loft_feats.add(loft_input)
-        return {"feature_name": feat.name, "operation": operation,
-                "profile_count": len(profile_sketch_names)}
+        return {
+            "feature_name": feat.name,
+            "operation": operation,
+            "profile_count": len(profile_sketch_names),
+        }
 
-    def fillet(self, radius: float, body_name: str = None,
-              body_index: int = 0, edge_selection: str = "all"):
+    def fillet(
+        self,
+        radius: float,
+        body_name: str = None,
+        body_index: int = 0,
+        edge_selection: str = "all",
+    ):
         root = self._root()
-        body = (self._body_by_name(body_name)
-                if body_name else root.bRepBodies.item(body_index))
+        body = (
+            self._body_by_name(body_name)
+            if body_name
+            else root.bRepBodies.item(body_index)
+        )
         edges = self._select_edges(body, edge_selection)
 
         fillets = root.features.filletFeatures
         inp = fillets.createInput()
         inp.addConstantRadiusEdgeSet(
-            edges, adsk.core.ValueInput.createByReal(radius), True)
+            edges, adsk.core.ValueInput.createByReal(radius), True
+        )
         feat = fillets.add(inp)
-        return {"feature_name": feat.name, "radius": radius,
-                "edges_count": edges.count}
+        return {"feature_name": feat.name, "radius": radius, "edges_count": edges.count}
 
-    def chamfer(self, distance: float, body_name: str = None,
-                body_index: int = 0, edge_selection: str = "all"):
+    def chamfer(
+        self,
+        distance: float,
+        body_name: str = None,
+        body_index: int = 0,
+        edge_selection: str = "all",
+    ):
         root = self._root()
-        body = (self._body_by_name(body_name)
-                if body_name else root.bRepBodies.item(body_index))
+        body = (
+            self._body_by_name(body_name)
+            if body_name
+            else root.bRepBodies.item(body_index)
+        )
         edges = self._select_edges(body, edge_selection)
 
         chamfers = root.features.chamferFeatures
         inp = chamfers.createInput(edges, True)
-        inp.setToEqualDistance(
-            adsk.core.ValueInput.createByReal(distance))
+        inp.setToEqualDistance(adsk.core.ValueInput.createByReal(distance))
         feat = chamfers.add(inp)
-        return {"feature_name": feat.name, "distance": distance,
-                "edges_count": edges.count}
+        return {
+            "feature_name": feat.name,
+            "distance": distance,
+            "edges_count": edges.count,
+        }
 
-    def shell(self, thickness: float, body_name: str = None,
-              body_index: int = 0, face_selection: str = "top"):
+    def shell(
+        self,
+        thickness: float,
+        body_name: str = None,
+        body_index: int = 0,
+        face_selection: str = "top",
+    ):
         root = self._root()
-        body = (self._body_by_name(body_name)
-                if body_name else root.bRepBodies.item(body_index))
+        body = (
+            self._body_by_name(body_name)
+            if body_name
+            else root.bRepBodies.item(body_index)
+        )
 
         faces = adsk.core.ObjectCollection.create()
         bbox = body.boundingBox
@@ -771,7 +980,8 @@ class CommandHandler:
                     faces.add(face)
         else:
             raise RuntimeError(
-                f"Unknown face_selection '{face_selection}' — use top/bottom")
+                f"Unknown face_selection '{face_selection}' — use top/bottom"
+            )
 
         if faces.count == 0:
             raise RuntimeError(f"No faces matched '{face_selection}'")
@@ -783,31 +993,44 @@ class CommandHandler:
         inp.facesToRemove = faces
         inp.insideThickness = adsk.core.ValueInput.createByReal(thickness)
         feat = shells.add(inp)
-        return {"feature_name": feat.name, "thickness": thickness,
-                "faces_removed": faces.count}
+        return {
+            "feature_name": feat.name,
+            "thickness": thickness,
+            "faces_removed": faces.count,
+        }
 
-    def mirror(self, mirror_plane: str, body_name: str = None,
-               body_index: int = 0):
+    def mirror(self, mirror_plane: str, body_name: str = None, body_index: int = 0):
         root = self._root()
-        body = (self._body_by_name(body_name)
-                if body_name else root.bRepBodies.item(body_index))
+        body = (
+            self._body_by_name(body_name)
+            if body_name
+            else root.bRepBodies.item(body_index)
+        )
 
         entities = adsk.core.ObjectCollection.create()
         entities.add(body)
 
         mirrors = root.features.mirrorFeatures
-        inp = mirrors.createInput(entities,
-                                  self._construction_plane(mirror_plane))
+        inp = mirrors.createInput(entities, self._construction_plane(mirror_plane))
         feat = mirrors.add(inp)
         return {"feature_name": feat.name, "mirror_plane": mirror_plane}
 
-    def create_hole(self, diameter: float, depth: float,
-                    body_name: str = None, body_index: int = 0,
-                    face_selection: str = "top",
-                    center_x: float = 0, center_y: float = 0):
+    def create_hole(
+        self,
+        diameter: float,
+        depth: float,
+        body_name: str = None,
+        body_index: int = 0,
+        face_selection: str = "top",
+        center_x: float = 0,
+        center_y: float = 0,
+    ):
         root = self._root()
-        body = (self._body_by_name(body_name)
-                if body_name else root.bRepBodies.item(body_index))
+        body = (
+            self._body_by_name(body_name)
+            if body_name
+            else root.bRepBodies.item(body_index)
+        )
 
         # Find the target face
         bbox = body.boundingBox
@@ -836,16 +1059,22 @@ class CommandHandler:
         # Create hole feature
         holes = root.features.holeFeatures
         hole_input = holes.createSimpleInput(
-            adsk.core.ValueInput.createByReal(diameter / 2))
+            adsk.core.ValueInput.createByReal(diameter / 2)
+        )
         hole_input.setPositionBySketchPoint(sketch_pt)
         hole_input.setDistanceExtent(adsk.core.ValueInput.createByReal(depth))
 
         feat = holes.add(hole_input)
         return {"feature_name": feat.name, "diameter": diameter, "depth": depth}
 
-    def rectangular_pattern(self, body_name: str,
-                            x_count: int = 1, x_spacing: float = 1.0,
-                            y_count: int = 1, y_spacing: float = 1.0):
+    def rectangular_pattern(
+        self,
+        body_name: str,
+        x_count: int = 1,
+        x_spacing: float = 1.0,
+        y_count: int = 1,
+        y_spacing: float = 1.0,
+    ):
         root = self._root()
         body = self._body_by_name(body_name)
 
@@ -853,19 +1082,24 @@ class CommandHandler:
         bodies.add(body)
 
         patterns = root.features.rectangularPatternFeatures
-        inp = patterns.createInput(bodies,
-                                   root.xConstructionAxis,
-                                   adsk.core.ValueInput.createByReal(x_count),
-                                   adsk.core.ValueInput.createByReal(x_spacing),
-                                   adsk.fusion.PatternDistanceType.SpacingPatternDistanceType)
-        inp.setDirectionTwo(root.yConstructionAxis,
-                           adsk.core.ValueInput.createByReal(y_count),
-                           adsk.core.ValueInput.createByReal(y_spacing))
+        inp = patterns.createInput(
+            bodies,
+            root.xConstructionAxis,
+            adsk.core.ValueInput.createByReal(x_count),
+            adsk.core.ValueInput.createByReal(x_spacing),
+            adsk.fusion.PatternDistanceType.SpacingPatternDistanceType,
+        )
+        inp.setDirectionTwo(
+            root.yConstructionAxis,
+            adsk.core.ValueInput.createByReal(y_count),
+            adsk.core.ValueInput.createByReal(y_spacing),
+        )
         feat = patterns.add(inp)
         return {"feature_name": feat.name, "x_count": x_count, "y_count": y_count}
 
-    def circular_pattern(self, body_name: str, count: int,
-                         axis: str = "z", total_angle: float = 360):
+    def circular_pattern(
+        self, body_name: str, count: int, axis: str = "z", total_angle: float = 360
+    ):
         root = self._root()
         body = self._body_by_name(body_name)
 
@@ -879,14 +1113,18 @@ class CommandHandler:
         feat = patterns.add(inp)
         return {"feature_name": feat.name, "count": count, "total_angle": total_angle}
 
-    def create_thread(self, body_name: str, face_index: int,
-                      is_internal: bool = False,
-                      thread_type: str = "ISO Metric profile",
-                      thread_designation: str = "M10x1.5",
-                      thread_class: str = "6g",
-                      is_modeled: bool = False,
-                      is_full_length: bool = True,
-                      thread_length: float = None):
+    def create_thread(
+        self,
+        body_name: str,
+        face_index: int,
+        is_internal: bool = False,
+        thread_type: str = "ISO Metric profile",
+        thread_designation: str = "M10x1.5",
+        thread_class: str = "6g",
+        is_modeled: bool = False,
+        is_full_length: bool = True,
+        thread_length: float = None,
+    ):
         root = self._root()
         body = self._body_by_name(body_name)
         face = body.faces.item(face_index)
@@ -904,23 +1142,35 @@ class CommandHandler:
         feat = threads.add(inp)
         return {"feature_name": feat.name, "thread_type": thread_type}
 
-    def draft_faces(self, body_name: str, angle: float,
-                    face_selection: str = "vertical",
-                    pull_direction_plane: str = "xy",
-                    is_tangent_chain: bool = True):
+    def draft_faces(
+        self,
+        body_name: str,
+        angle: float,
+        face_selection: str = "vertical",
+        pull_direction_plane: str = "xy",
+        is_tangent_chain: bool = True,
+    ):
         root = self._root()
         body = self._body_by_name(body_name)
         faces = self._select_faces(body, face_selection)
 
         drafts = root.features.draftFeatures
-        inp = drafts.createInput(faces, self._construction_plane(pull_direction_plane),
-                                 adsk.core.ValueInput.createByString(f"{angle} deg"),
-                                 is_tangent_chain)
+        inp = drafts.createInput(
+            faces,
+            self._construction_plane(pull_direction_plane),
+            adsk.core.ValueInput.createByString(f"{angle} deg"),
+            is_tangent_chain,
+        )
         feat = drafts.add(inp)
         return {"feature_name": feat.name, "angle": angle}
 
-    def split_body(self, body_name: str, splitting_plane: str = "xy",
-                   splitting_body: str = None, extend_tool: bool = True):
+    def split_body(
+        self,
+        body_name: str,
+        splitting_plane: str = "xy",
+        splitting_body: str = None,
+        extend_tool: bool = True,
+    ):
         root = self._root()
         body = self._body_by_name(body_name)
 
@@ -929,13 +1179,19 @@ class CommandHandler:
             tool = self._body_by_name(splitting_body)
             inp = splits.createInput(body, tool, extend_tool)
         else:
-            inp = splits.createInput(body, self._construction_plane(splitting_plane),
-                                     extend_tool)
+            inp = splits.createInput(
+                body, self._construction_plane(splitting_plane), extend_tool
+            )
         feat = splits.add(inp)
         return {"feature_name": feat.name, "splitting_plane": splitting_plane}
 
-    def split_face(self, body_name: str, face_indices: list = None,
-                   splitting_plane: str = "xy", extend_tool: bool = True):
+    def split_face(
+        self,
+        body_name: str,
+        face_indices: list = None,
+        splitting_plane: str = "xy",
+        extend_tool: bool = True,
+    ):
         root = self._root()
         body = self._body_by_name(body_name)
 
@@ -948,13 +1204,19 @@ class CommandHandler:
                 faces.add(face)
 
         splits = root.features.splitFaceFeatures
-        inp = splits.createInput(faces, self._construction_plane(splitting_plane),
-                                 extend_tool)
+        inp = splits.createInput(
+            faces, self._construction_plane(splitting_plane), extend_tool
+        )
         feat = splits.add(inp)
         return {"feature_name": feat.name}
 
-    def offset_faces(self, body_name: str, distance: float,
-                     face_selection: str = "top", face_indices: list = None):
+    def offset_faces(
+        self,
+        body_name: str,
+        distance: float,
+        face_selection: str = "top",
+        face_indices: list = None,
+    ):
         root = self._root()
         body = self._body_by_name(body_name)
 
@@ -966,17 +1228,25 @@ class CommandHandler:
             faces = self._select_faces(body, face_selection)
 
         offsets = root.features.offsetFeatures
-        inp = offsets.createInput(faces,
-                                  adsk.core.ValueInput.createByReal(distance),
-                                  adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
+        inp = offsets.createInput(
+            faces,
+            adsk.core.ValueInput.createByReal(distance),
+            adsk.fusion.FeatureOperations.NewBodyFeatureOperation,
+        )
         feat = offsets.add(inp)
         return {"feature_name": feat.name, "distance": distance}
 
-    def scale_body(self, body_name: str, scale: float,
-                   scale_x: float = None, scale_y: float = None,
-                   scale_z: float = None,
-                   anchor_x: float = 0, anchor_y: float = 0,
-                   anchor_z: float = 0):
+    def scale_body(
+        self,
+        body_name: str,
+        scale: float,
+        scale_x: float = None,
+        scale_y: float = None,
+        scale_z: float = None,
+        anchor_x: float = 0,
+        anchor_y: float = 0,
+        anchor_z: float = 0,
+    ):
         root = self._root()
         body = self._body_by_name(body_name)
 
@@ -987,13 +1257,17 @@ class CommandHandler:
 
         scales = root.features.scaleFeatures
         if scale_x is not None and scale_y is not None and scale_z is not None:
-            inp = scales.createInput(bodies, anchor,
-                                     adsk.core.ValueInput.createByReal(scale_x),
-                                     adsk.core.ValueInput.createByReal(scale_y),
-                                     adsk.core.ValueInput.createByReal(scale_z))
+            inp = scales.createInput(
+                bodies,
+                anchor,
+                adsk.core.ValueInput.createByReal(scale_x),
+                adsk.core.ValueInput.createByReal(scale_y),
+                adsk.core.ValueInput.createByReal(scale_z),
+            )
         else:
-            inp = scales.createInput(bodies, anchor,
-                                     adsk.core.ValueInput.createByReal(scale))
+            inp = scales.createInput(
+                bodies, anchor, adsk.core.ValueInput.createByReal(scale)
+            )
         feat = scales.add(inp)
         return {"feature_name": feat.name, "scale": scale}
 
@@ -1001,7 +1275,7 @@ class CommandHandler:
         design = self._design()
         for i in range(design.timeline.count):
             item = design.timeline.item(i)
-            has_entity = hasattr(item, 'entity') and item.entity
+            has_entity = hasattr(item, "entity") and item.entity
             if has_entity and item.entity.name == feature_name:
                 item.isSuppressed = True
                 return {"suppressed": True, "feature": feature_name}
@@ -1011,7 +1285,7 @@ class CommandHandler:
         design = self._design()
         for i in range(design.timeline.count):
             item = design.timeline.item(i)
-            has_entity = hasattr(item, 'entity') and item.entity
+            has_entity = hasattr(item, "entity") and item.entity
             if has_entity and item.entity.name == feature_name:
                 item.isSuppressed = False
                 return {"unsuppressed": True, "feature": feature_name}
@@ -1021,8 +1295,7 @@ class CommandHandler:
     # Body Operations
     # ------------------------------------------------------------------
 
-    def move_body(self, body_name: str, x: float = 0, y: float = 0,
-                  z: float = 0):
+    def move_body(self, body_name: str, x: float = 0, y: float = 0, z: float = 0):
         root = self._root()
         body = self._body_by_name(body_name)
 
@@ -1035,8 +1308,7 @@ class CommandHandler:
 
         inp = move_feats.createInput(bodies, transform)
         feat = move_feats.add(inp)
-        return {"feature_name": feat.name, "body": body_name,
-                "translation": [x, y, z]}
+        return {"feature_name": feat.name, "body": body_name, "translation": [x, y, z]}
 
     def export_stl(self, body_name: str, file_path: str = None):
         body = self._body_by_name(body_name)
@@ -1050,7 +1322,8 @@ class CommandHandler:
         export_mgr = self._design().exportManager
         stl_opts = export_mgr.createSTLExportOptions(body, file_path)
         stl_opts.meshRefinement = (
-            adsk.fusion.MeshRefinementSettings.MeshRefinementMedium)
+            adsk.fusion.MeshRefinementSettings.MeshRefinementMedium
+        )
         export_mgr.execute(stl_opts)
 
         return {"exported": True, "body": body_name, "file_path": file_path}
@@ -1086,8 +1359,9 @@ class CommandHandler:
 
         return {"exported": True, "file_path": file_path}
 
-    def boolean_operation(self, target_body: str, tool_body: str,
-                          operation: str = "join"):
+    def boolean_operation(
+        self, target_body: str, tool_body: str, operation: str = "join"
+    ):
         root = self._root()
         target = self._body_by_name(target_body)
         tool = self._body_by_name(tool_body)
@@ -1097,20 +1371,25 @@ class CommandHandler:
         tool_coll.add(tool)
 
         op_map = {
-            "join":      adsk.fusion.FeatureOperations.JoinFeatureOperation,
-            "cut":       adsk.fusion.FeatureOperations.CutFeatureOperation,
+            "join": adsk.fusion.FeatureOperations.JoinFeatureOperation,
+            "cut": adsk.fusion.FeatureOperations.CutFeatureOperation,
             "intersect": adsk.fusion.FeatureOperations.IntersectFeatureOperation,
         }
         op = op_map.get(operation)
         if op is None:
             raise RuntimeError(
-                f"Unknown boolean op '{operation}' — use join/cut/intersect")
+                f"Unknown boolean op '{operation}' — use join/cut/intersect"
+            )
 
         inp = combine_feats.createInput(target, tool_coll)
         inp.operation = op
         feat = combine_feats.add(inp)
-        return {"feature_name": feat.name, "operation": operation,
-                "target": target_body, "tool": tool_body}
+        return {
+            "feature_name": feat.name,
+            "operation": operation,
+            "target": target_body,
+            "tool": tool_body,
+        }
 
     def delete_all(self):
         design = self._design()
@@ -1127,7 +1406,7 @@ class CommandHandler:
         design = self._design()
         type_before = design.designType
 
-        cmd_def = self.ui.commandDefinitions.itemById('UndoCommand')
+        cmd_def = self.ui.commandDefinitions.itemById("UndoCommand")
         if cmd_def:
             cmd_def.execute()
 
@@ -1136,7 +1415,7 @@ class CommandHandler:
         type_after = design.designType
         if type_before != type_after:
             # Undo the undo — redo to restore original state
-            redo_def = self.ui.commandDefinitions.itemById('RedoCommand')
+            redo_def = self.ui.commandDefinitions.itemById("RedoCommand")
             if redo_def:
                 redo_def.execute()
                 adsk.doEvents()
@@ -1154,18 +1433,27 @@ class CommandHandler:
     # Direct Primitives (via TemporaryBRepManager)
     # ------------------------------------------------------------------
 
-    def create_box(self, length: float, width: float, height: float,
-                   center_x: float = 0, center_y: float = 0,
-                   center_z: float = 0):
+    def create_box(
+        self,
+        length: float,
+        width: float,
+        height: float,
+        center_x: float = 0,
+        center_y: float = 0,
+        center_z: float = 0,
+    ):
         root = self._root()
         temp_brep = adsk.fusion.TemporaryBRepManager.get()
 
         # Box orientation matrix
         orient = adsk.core.OrientedBoundingBox3D.create(
-            adsk.core.Point3D.create(center_x, center_y, center_z + height/2),
+            adsk.core.Point3D.create(center_x, center_y, center_z + height / 2),
             adsk.core.Vector3D.create(1, 0, 0),
             adsk.core.Vector3D.create(0, 1, 0),
-            length, width, height)
+            length,
+            width,
+            height,
+        )
 
         box_body = temp_brep.createBox(orient)
         base_feat = root.features.baseFeatures.add()
@@ -1173,12 +1461,17 @@ class CommandHandler:
         root.bRepBodies.add(box_body, base_feat)
         base_feat.finishEdit()
 
-        return {"created": True, "length": length, "width": width,
-                "height": height}
+        return {"created": True, "length": length, "width": width, "height": height}
 
-    def create_cylinder(self, radius: float, height: float,
-                        base_x: float = 0, base_y: float = 0,
-                        base_z: float = 0, axis: str = "z"):
+    def create_cylinder(
+        self,
+        radius: float,
+        height: float,
+        base_x: float = 0,
+        base_y: float = 0,
+        base_z: float = 0,
+        axis: str = "z",
+    ):
         root = self._root()
         temp_brep = adsk.fusion.TemporaryBRepManager.get()
 
@@ -1187,7 +1480,8 @@ class CommandHandler:
         top_pt = adsk.core.Point3D.create(
             base_x + axis_vec[0] * height,
             base_y + axis_vec[1] * height,
-            base_z + axis_vec[2] * height)
+            base_z + axis_vec[2] * height,
+        )
 
         cyl_body = temp_brep.createCylinderOrCone(base_pt, radius, top_pt, radius)
 
@@ -1198,9 +1492,13 @@ class CommandHandler:
 
         return {"created": True, "radius": radius, "height": height}
 
-    def create_sphere(self, radius: float,
-                      center_x: float = 0, center_y: float = 0,
-                      center_z: float = 0):
+    def create_sphere(
+        self,
+        radius: float,
+        center_x: float = 0,
+        center_y: float = 0,
+        center_z: float = 0,
+    ):
         root = self._root()
         temp_brep = adsk.fusion.TemporaryBRepManager.get()
 
@@ -1214,9 +1512,15 @@ class CommandHandler:
 
         return {"created": True, "radius": radius}
 
-    def create_torus(self, major_radius: float, minor_radius: float,
-                     center_x: float = 0, center_y: float = 0,
-                     center_z: float = 0, axis: str = "z"):
+    def create_torus(
+        self,
+        major_radius: float,
+        minor_radius: float,
+        center_x: float = 0,
+        center_y: float = 0,
+        center_z: float = 0,
+        axis: str = "z",
+    ):
         root = self._root()
         temp_brep = adsk.fusion.TemporaryBRepManager.get()
 
@@ -1224,41 +1528,57 @@ class CommandHandler:
         axis_vec = {"x": (1, 0, 0), "y": (0, 1, 0), "z": (0, 0, 1)}[axis]
         axis_vector = adsk.core.Vector3D.create(*axis_vec)
 
-        torus_body = temp_brep.createTorus(center, axis_vector,
-                                           major_radius, minor_radius)
+        torus_body = temp_brep.createTorus(
+            center, axis_vector, major_radius, minor_radius
+        )
 
         base_feat = root.features.baseFeatures.add()
         base_feat.startEdit()
         root.bRepBodies.add(torus_body, base_feat)
         base_feat.finishEdit()
 
-        return {"created": True, "major_radius": major_radius,
-                "minor_radius": minor_radius}
+        return {
+            "created": True,
+            "major_radius": major_radius,
+            "minor_radius": minor_radius,
+        }
 
     # ------------------------------------------------------------------
     # Construction Geometry
     # ------------------------------------------------------------------
 
-    def create_construction_plane(self, method: str,
-                                  plane: str = None, offset: float = None,
-                                  angle: float = None, edge_name: str = None,
-                                  plane_one: str = None, plane_two: str = None,
-                                  point_one: list = None, point_two: list = None,
-                                  point_three: list = None):
+    def create_construction_plane(
+        self,
+        method: str,
+        plane: str = None,
+        offset: float = None,
+        angle: float = None,
+        edge_name: str = None,
+        plane_one: str = None,
+        plane_two: str = None,
+        point_one: list = None,
+        point_two: list = None,
+        point_three: list = None,
+    ):
         root = self._root()
         planes = root.constructionPlanes
         inp = planes.createInput()
 
         if method == "offset":
-            inp.setByOffset(self._construction_plane(plane),
-                           adsk.core.ValueInput.createByReal(offset))
+            inp.setByOffset(
+                self._construction_plane(plane),
+                adsk.core.ValueInput.createByReal(offset),
+            )
         elif method == "angle":
-            inp.setByAngle(self._construction_axis(edge_name or "x"),
-                          adsk.core.ValueInput.createByString(f"{angle} deg"),
-                          self._construction_plane(plane))
+            inp.setByAngle(
+                self._construction_axis(edge_name or "x"),
+                adsk.core.ValueInput.createByString(f"{angle} deg"),
+                self._construction_plane(plane),
+            )
         elif method == "midplane":
-            inp.setByTwoPlanes(self._construction_plane(plane_one),
-                              self._construction_plane(plane_two))
+            inp.setByTwoPlanes(
+                self._construction_plane(plane_one), self._construction_plane(plane_two)
+            )
         elif method == "three_points":
             p1 = adsk.core.Point3D.create(*point_one)
             p2 = adsk.core.Point3D.create(*point_two)
@@ -1272,10 +1592,16 @@ class CommandHandler:
         plane_obj = planes.add(inp)
         return {"created": True, "name": plane_obj.name, "method": method}
 
-    def create_construction_axis(self, method: str,
-                                 point_one: list = None, point_two: list = None,
-                                 plane_one: str = None, plane_two: str = None,
-                                 body_name: str = None, edge_index: int = None):
+    def create_construction_axis(
+        self,
+        method: str,
+        point_one: list = None,
+        point_two: list = None,
+        plane_one: str = None,
+        plane_two: str = None,
+        body_name: str = None,
+        edge_index: int = None,
+    ):
         root = self._root()
         axes = root.constructionAxes
         inp = axes.createInput()
@@ -1285,8 +1611,9 @@ class CommandHandler:
             p2 = adsk.core.Point3D.create(*point_two)
             inp.setByTwoPoints(p1, p2)
         elif method == "intersection":
-            inp.setByTwoPlanes(self._construction_plane(plane_one),
-                              self._construction_plane(plane_two))
+            inp.setByTwoPlanes(
+                self._construction_plane(plane_one), self._construction_plane(plane_two)
+            )
         elif method == "edge":
             body = self._body_by_name(body_name)
             edge = body.edges.item(edge_index)
@@ -1306,15 +1633,15 @@ class CommandHandler:
 
     def create_component(self, name: str, parent_name: str = None):
         root = self._root()
-        parent = (self._component_by_name(parent_name) if parent_name
-                  else root)
+        parent = self._component_by_name(parent_name) if parent_name else root
 
         occ = parent.occurrences.addNewComponent(adsk.core.Matrix3D.create())
         occ.component.name = name
         return {"created": True, "name": name}
 
-    def add_joint(self, component_one: str, component_two: str,
-                  joint_type: str = "rigid"):
+    def add_joint(
+        self, component_one: str, component_two: str, joint_type: str = "rigid"
+    ):
         root = self._root()
 
         occ1 = occ2 = None
@@ -1354,8 +1681,9 @@ class CommandHandler:
         joints.add(inp)
         return {"created": True, "joint_type": joint_type}
 
-    def create_as_built_joint(self, component_one: str, component_two: str,
-                              joint_type: str = "rigid"):
+    def create_as_built_joint(
+        self, component_one: str, component_two: str, joint_type: str = "rigid"
+    ):
         root = self._root()
 
         occ1 = occ2 = None
@@ -1373,8 +1701,7 @@ class CommandHandler:
         as_built.add(inp)
         return {"created": True, "joint_type": joint_type}
 
-    def create_rigid_group(self, component_names: list,
-                           include_children: bool = True):
+    def create_rigid_group(self, component_names: list, include_children: bool = True):
         root = self._root()
         occs = adsk.core.ObjectCollection.create()
 
@@ -1415,13 +1742,19 @@ class CommandHandler:
 
         measure = self.app.measureManager
         result = measure.measureMinimumDistance(e1, e2)
-        return {"distance": result.value,
-                "point_one": [result.pointOnEntityOne.x,
-                             result.pointOnEntityOne.y,
-                             result.pointOnEntityOne.z],
-                "point_two": [result.pointOnEntityTwo.x,
-                             result.pointOnEntityTwo.y,
-                             result.pointOnEntityTwo.z]}
+        return {
+            "distance": result.value,
+            "point_one": [
+                result.pointOnEntityOne.x,
+                result.pointOnEntityOne.y,
+                result.pointOnEntityOne.z,
+            ],
+            "point_two": [
+                result.pointOnEntityTwo.x,
+                result.pointOnEntityTwo.y,
+                result.pointOnEntityTwo.z,
+            ],
+        }
 
     def measure_angle(self, entity_one: str, entity_two: str):
         root = self._root()
@@ -1440,8 +1773,7 @@ class CommandHandler:
         result = measure.measureAngle(e1, e2)
         return {"angle_degrees": math.degrees(result.value)}
 
-    def get_physical_properties(self, body_name: str,
-                                accuracy: str = "medium"):
+    def get_physical_properties(self, body_name: str, accuracy: str = "medium"):
         body = self._body_by_name(body_name)
 
         accuracy_map = {
@@ -1458,9 +1790,11 @@ class CommandHandler:
             "volume": props.volume,
             "area": props.area,
             "density": props.density,
-            "center_of_mass": [props.centerOfMass.x,
-                              props.centerOfMass.y,
-                              props.centerOfMass.z],
+            "center_of_mass": [
+                props.centerOfMass.x,
+                props.centerOfMass.y,
+                props.centerOfMass.z,
+            ],
         }
 
     def create_section_analysis(self, plane: str = "yz", offset: float = 0):
@@ -1475,8 +1809,9 @@ class CommandHandler:
         analyses.add(inp)
         return {"created": True, "plane": plane, "offset": offset}
 
-    def check_interference(self, component_names: list,
-                           include_coincident_faces: bool = False):
+    def check_interference(
+        self, component_names: list, include_coincident_faces: bool = False
+    ):
         root = self._root()
         bodies = adsk.core.ObjectCollection.create()
 
@@ -1493,11 +1828,13 @@ class CommandHandler:
         results = []
         for i in range(interference.interferenceResultCount):
             result = interference.interferenceResult(i)
-            results.append({
-                "body_one": result.entityOne.name,
-                "body_two": result.entityTwo.name,
-                "volume": result.interferenceBody.volume,
-            })
+            results.append(
+                {
+                    "body_one": result.entityOne.name,
+                    "body_two": result.entityTwo.name,
+                    "volume": result.interferenceBody.volume,
+                }
+            )
 
         return {"interferences": results, "count": len(results)}
 
@@ -1505,8 +1842,13 @@ class CommandHandler:
     # Appearance
     # ------------------------------------------------------------------
 
-    def set_appearance(self, target_name: str, appearance_name: str,
-                       target_type: str = "body", face_index: int = None):
+    def set_appearance(
+        self,
+        target_name: str,
+        appearance_name: str,
+        target_type: str = "body",
+        face_index: int = None,
+    ):
         # Find appearance in library
         app_lib = self.app.materialLibraries.itemByName("Fusion 360 Appearance Library")
         appearance = None
@@ -1530,8 +1872,7 @@ class CommandHandler:
             face = body.faces.item(face_index)
             face.appearance = appearance
 
-        return {"applied": True, "target": target_name,
-                "appearance": appearance_name}
+        return {"applied": True, "target": target_name, "appearance": appearance_name}
 
     # ------------------------------------------------------------------
     # Parameters
@@ -1541,21 +1882,23 @@ class CommandHandler:
         design = self._design()
         params = []
         for param in design.userParameters:
-            params.append({
-                "name": param.name,
-                "value": param.value,
-                "expression": param.expression,
-                "unit": param.unit,
-                "comment": param.comment,
-            })
+            params.append(
+                {
+                    "name": param.name,
+                    "value": param.value,
+                    "expression": param.expression,
+                    "unit": param.unit,
+                    "comment": param.comment,
+                }
+            )
         return {"parameters": params, "count": len(params)}
 
-    def create_parameter(self, name: str, value: float, unit: str,
-                         comment: str = None):
+    def create_parameter(self, name: str, value: float, unit: str, comment: str = None):
         design = self._design()
         params = design.userParameters
-        inp = params.createInput(name, adsk.core.ValueInput.createByReal(value),
-                                 unit, comment or "")
+        inp = params.createInput(
+            name, adsk.core.ValueInput.createByReal(value), unit, comment or ""
+        )
         params.add(inp)
         return {"created": True, "name": name, "value": value, "unit": unit}
 
@@ -1579,8 +1922,9 @@ class CommandHandler:
     # Surface Operations
     # ------------------------------------------------------------------
 
-    def patch_surface(self, sketch_name: str, profile_index: int = 0,
-                      continuity: str = "connected"):
+    def patch_surface(
+        self, sketch_name: str, profile_index: int = 0, continuity: str = "connected"
+    ):
         root = self._root()
         sketch = self._sketch_by_name(sketch_name)
 
@@ -1589,8 +1933,9 @@ class CommandHandler:
         profile = sketch.profiles.item(profile_index)
 
         patches = root.features.patchFeatures
-        inp = patches.createInput(profile,
-                                  adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
+        inp = patches.createInput(
+            profile, adsk.fusion.FeatureOperations.NewBodyFeatureOperation
+        )
 
         sct = adsk.fusion.SurfaceContinuityTypes
         cont_map = {
@@ -1610,14 +1955,17 @@ class CommandHandler:
             bodies.add(self._body_by_name(name))
 
         stitches = root.features.stitchFeatures
-        inp = stitches.createInput(bodies,
-                                   adsk.core.ValueInput.createByReal(tolerance),
-                                   adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
+        inp = stitches.createInput(
+            bodies,
+            adsk.core.ValueInput.createByReal(tolerance),
+            adsk.fusion.FeatureOperations.NewBodyFeatureOperation,
+        )
         feat = stitches.add(inp)
         return {"feature_name": feat.name, "body_count": len(body_names)}
 
-    def thicken_surface(self, body_name: str, thickness: float,
-                        direction: str = "symmetric"):
+    def thicken_surface(
+        self, body_name: str, thickness: float, direction: str = "symmetric"
+    ):
         root = self._root()
         body = self._body_by_name(body_name)
 
@@ -1626,23 +1974,29 @@ class CommandHandler:
             faces.add(face)
 
         thickens = root.features.thickenFeatures
-        inp = thickens.createInput(faces,
-                                   adsk.core.ValueInput.createByReal(thickness),
-                                   False,
-                                   adsk.fusion.FeatureOperations.NewBodyFeatureOperation,
-                                   direction == "symmetric")
+        inp = thickens.createInput(
+            faces,
+            adsk.core.ValueInput.createByReal(thickness),
+            False,
+            adsk.fusion.FeatureOperations.NewBodyFeatureOperation,
+            direction == "symmetric",
+        )
         feat = thickens.add(inp)
         return {"feature_name": feat.name, "thickness": thickness}
 
-    def ruled_surface(self, body_name: str, edge_index: int,
-                      distance: float = 1.0, rule_type: str = "normal"):
+    def ruled_surface(
+        self,
+        body_name: str,
+        edge_index: int,
+        distance: float = 1.0,
+        rule_type: str = "normal",
+    ):
         root = self._root()
         body = self._body_by_name(body_name)
         edge = body.edges.item(edge_index)
 
         ruled = root.features.ruledSurfaceFeatures
-        inp = ruled.createInput(edge,
-                                adsk.core.ValueInput.createByReal(distance))
+        inp = ruled.createInput(edge, adsk.core.ValueInput.createByReal(distance))
         feat = ruled.add(inp)
         return {"feature_name": feat.name, "distance": distance}
 
@@ -1660,9 +2014,14 @@ class CommandHandler:
     # Sheet Metal
     # ------------------------------------------------------------------
 
-    def create_flange(self, body_name: str, edge_index: int,
-                      height: float = 1.0, angle: float = 90,
-                      bend_radius: float = None):
+    def create_flange(
+        self,
+        body_name: str,
+        edge_index: int,
+        height: float = 1.0,
+        angle: float = 90,
+        bend_radius: float = None,
+    ):
         root = self._root()
         body = self._body_by_name(body_name)
         edge = body.edges.item(edge_index)
@@ -1677,8 +2036,13 @@ class CommandHandler:
         feat = flanges.add(inp)
         return {"feature_name": feat.name, "height": height, "angle": angle}
 
-    def create_bend(self, body_name: str, bend_line_sketch: str = None,
-                    angle: float = 90, bend_radius: float = None):
+    def create_bend(
+        self,
+        body_name: str,
+        bend_line_sketch: str = None,
+        angle: float = 90,
+        bend_radius: float = None,
+    ):
         root = self._root()
         body = self._body_by_name(body_name)
 
@@ -1743,11 +2107,12 @@ class CommandHandler:
     def _get_cam(self):
         """Get the CAM product from the active document."""
         doc = self.app.activeDocument
-        cam_product = doc.products.itemByProductType('CAMProductType')
+        cam_product = doc.products.itemByProductType("CAMProductType")
         if not cam_product:
             raise RuntimeError(
                 "No CAM workspace found. Open the Manufacturing workspace "
-                "in Fusion 360 at least once to initialise it.")
+                "in Fusion 360 at least once to initialise it."
+            )
         return cam_product
 
     def _find_setup(self, cam, name: str):
@@ -1772,11 +2137,13 @@ class CommandHandler:
             ops = []
             for j in range(setup.operations.count):
                 ops.append(setup.operations.item(j).name)
-            result.append({
-                "name": setup.name,
-                "operations": ops,
-                "is_valid": setup.isValid,
-            })
+            result.append(
+                {
+                    "name": setup.name,
+                    "operations": ops,
+                    "is_valid": setup.isValid,
+                }
+            )
         return {"setups": result, "count": len(result)}
 
     def cam_list_operations(self, setup_name: str):
@@ -1785,11 +2152,13 @@ class CommandHandler:
         result = []
         for i in range(setup.operations.count):
             op = setup.operations.item(i)
-            result.append({
-                "name": op.name,
-                "has_toolpath": op.hasToolpath,
-                "is_valid": op.isValid,
-            })
+            result.append(
+                {
+                    "name": op.name,
+                    "has_toolpath": op.hasToolpath,
+                    "is_valid": op.isValid,
+                }
+            )
         return {"setup": setup_name, "operations": result, "count": len(result)}
 
     def cam_get_operation_info(self, setup_name: str, operation_name: str):
@@ -1803,12 +2172,12 @@ class CommandHandler:
             "has_toolpath": op.hasToolpath,
         }
 
-        if hasattr(op, 'tool') and op.tool:
+        if hasattr(op, "tool") and op.tool:
             tool = op.tool
-            desc = tool.description if hasattr(tool, 'description') else str(tool)
+            desc = tool.description if hasattr(tool, "description") else str(tool)
             info["tool"] = {"description": desc}
 
-        if hasattr(op, 'parameters'):
+        if hasattr(op, "parameters"):
             params = {}
             for param in op.parameters:
                 try:
@@ -1819,12 +2188,16 @@ class CommandHandler:
 
         return info
 
-    def cam_create_setup(self, body_name: str, name: str = None,
-                         operation_type: str = "milling",
-                         stock_mode: str = "relative_box",
-                         stock_offset_sides: float = 0,
-                         stock_offset_top: float = 0,
-                         stock_offset_bottom: float = 0):
+    def cam_create_setup(
+        self,
+        body_name: str,
+        name: str = None,
+        operation_type: str = "milling",
+        stock_mode: str = "relative_box",
+        stock_offset_sides: float = 0,
+        stock_offset_top: float = 0,
+        stock_offset_bottom: float = 0,
+    ):
         cam = self._get_cam()
         body = self._body_by_name(body_name)
 
@@ -1837,7 +2210,8 @@ class CommandHandler:
         if op_type is None:
             raise RuntimeError(
                 f"Unknown operation_type '{operation_type}' "
-                "— use milling/turning/cutting")
+                "— use milling/turning/cutting"
+            )
 
         setup_input = cam.setups.createInput(op_type)
         setup_input.models = [body]
@@ -1846,18 +2220,21 @@ class CommandHandler:
             setup_input.name = name
 
         setup = cam.setups.add(setup_input)
-        return {"name": setup.name, "body": body_name,
-                "operation_type": operation_type}
+        return {"name": setup.name, "body": body_name, "operation_type": operation_type}
 
-    def cam_create_operation(self, setup_name: str, strategy: str,
-                              name: str = None,
-                              tool_number: int = None,
-                              tool_diameter: float = None,
-                              stepdown: float = None,
-                              stepover: float = None,
-                              feed_rate: float = None,
-                              spindle_speed: float = None,
-                              coolant: str = "flood"):
+    def cam_create_operation(
+        self,
+        setup_name: str,
+        strategy: str,
+        name: str = None,
+        tool_number: int = None,
+        tool_diameter: float = None,
+        stepdown: float = None,
+        stepover: float = None,
+        feed_rate: float = None,
+        spindle_speed: float = None,
+        coolant: str = "flood",
+    ):
         cam = self._get_cam()
         setup = self._find_setup(cam, setup_name)
 
@@ -1874,9 +2251,12 @@ class CommandHandler:
         op = setup.operations.add(op_input)
         return {"name": op.name, "setup": setup_name, "strategy": strategy}
 
-    def cam_generate_toolpath(self, setup_name: str = None,
-                               operation_name: str = None,
-                               generate_all: bool = False):
+    def cam_generate_toolpath(
+        self,
+        setup_name: str = None,
+        operation_name: str = None,
+        generate_all: bool = False,
+    ):
         cam = self._get_cam()
 
         if generate_all:
@@ -1889,8 +2269,11 @@ class CommandHandler:
             op = self._find_operation(setup, operation_name)
             future = cam.generateToolpath(op)
             future.wait()
-            return {"generated": True, "scope": "operation",
-                    "operation": operation_name}
+            return {
+                "generated": True,
+                "scope": "operation",
+                "operation": operation_name,
+            }
 
         if setup_name:
             setup = self._find_setup(cam, setup_name)
@@ -1901,28 +2284,33 @@ class CommandHandler:
             future.wait()
             return {"generated": True, "scope": "setup", "setup": setup_name}
 
-        raise RuntimeError(
-            "Provide setup_name, operation_name, or generate_all=true")
+        raise RuntimeError("Provide setup_name, operation_name, or generate_all=true")
 
-    def cam_post_process(self, setup_name: str, operation_name: str = None,
-                          post_processor: str = "fanuc",
-                          output_folder: str = None,
-                          output_units: str = "mm"):
+    def cam_post_process(
+        self,
+        setup_name: str,
+        operation_name: str = None,
+        post_processor: str = "fanuc",
+        output_folder: str = None,
+        output_units: str = "mm",
+    ):
         cam = self._get_cam()
         setup = self._find_setup(cam, setup_name)
 
         if not output_folder:
             output_folder = os.path.join(os.path.expanduser("~"), "Desktop")
 
-        post_config = os.path.join(
-            cam.genericPostFolder, f"{post_processor}.cps")
+        post_config = os.path.join(cam.genericPostFolder, f"{post_processor}.cps")
 
-        units = (adsk.cam.PostOutputUnitOptions.MillimetersOutput
-                 if output_units == "mm"
-                 else adsk.cam.PostOutputUnitOptions.InchesOutput)
+        units = (
+            adsk.cam.PostOutputUnitOptions.MillimetersOutput
+            if output_units == "mm"
+            else adsk.cam.PostOutputUnitOptions.InchesOutput
+        )
 
         post_input = adsk.cam.PostProcessInput.create(
-            setup_name, post_config, output_folder, units)
+            setup_name, post_config, output_folder, units
+        )
         post_input.isOpenInEditor = False
 
         if operation_name:
@@ -1931,8 +2319,12 @@ class CommandHandler:
         else:
             cam.postProcess(setup, post_input)
 
-        return {"setup": setup_name, "post_processor": post_processor,
-                "output_folder": output_folder, "units": output_units}
+        return {
+            "setup": setup_name,
+            "post_processor": post_processor,
+            "output_folder": output_folder,
+            "units": output_units,
+        }
 
     # ------------------------------------------------------------------
     # Health check
@@ -1950,7 +2342,9 @@ class CommandHandler:
         design = self._design()
         dt = design.designType
         return {
-            "design_type": "parametric" if dt == adsk.fusion.DesignTypes.ParametricDesignType else "direct",
+            "design_type": "parametric"
+            if dt == adsk.fusion.DesignTypes.ParametricDesignType
+            else "direct",
             "design_type_id": dt,
         }
 
@@ -1963,8 +2357,11 @@ class CommandHandler:
         if design_type == "parametric":
             target = adsk.fusion.DesignTypes.ParametricDesignType
             if current == target:
-                return {"changed": False, "design_type": "parametric",
-                        "message": "Already in parametric mode"}
+                return {
+                    "changed": False,
+                    "design_type": "parametric",
+                    "message": "Already in parametric mode",
+                }
             design.designType = target
             adsk.doEvents()
             # Verify it actually changed
@@ -1978,16 +2375,18 @@ class CommandHandler:
         elif design_type == "direct":
             target = adsk.fusion.DesignTypes.DirectDesignType
             if current == target:
-                return {"changed": False, "design_type": "direct",
-                        "message": "Already in direct mode"}
+                return {
+                    "changed": False,
+                    "design_type": "direct",
+                    "message": "Already in direct mode",
+                }
             design.designType = target
             adsk.doEvents()
             return {"changed": True, "design_type": "direct"}
 
         else:
             raise RuntimeError(
-                f"Invalid design_type '{design_type}'. "
-                f"Use 'parametric' or 'direct'."
+                f"Invalid design_type '{design_type}'. Use 'parametric' or 'direct'."
             )
 
     # ------------------------------------------------------------------
@@ -2019,10 +2418,13 @@ class CommandHandler:
             last_node = tree.body.pop()
             if tree.body:
                 with redirect_stdout(buf):
-                    exec(compile(ast.Module(body=tree.body, type_ignores=[]),
-                                 "<mcp>", "exec"), ns)
-            expr_code = compile(ast.Expression(body=last_node.value),
-                                "<mcp>", "eval")
+                    exec(
+                        compile(
+                            ast.Module(body=tree.body, type_ignores=[]), "<mcp>", "exec"
+                        ),
+                        ns,
+                    )
+            expr_code = compile(ast.Expression(body=last_node.value), "<mcp>", "eval")
             with redirect_stdout(buf):
                 last_expr_value = eval(expr_code, ns)
         else:
@@ -2046,6 +2448,7 @@ class CommandHandler:
         if result is not None:
             try:
                 import json as _json
+
                 _json.dumps(result)
             except (TypeError, ValueError):
                 result = str(result)
@@ -2076,3 +2479,178 @@ class CommandHandler:
             "min": [bbox.minPoint.x, bbox.minPoint.y, bbox.minPoint.z],
             "max": [bbox.maxPoint.x, bbox.maxPoint.y, bbox.maxPoint.z],
         }
+
+    # ------------------------------------------------------------------
+    # Mutation snapshot (before/after deltas for feedback)
+    # ------------------------------------------------------------------
+
+    def _snapshot(self) -> dict | None:
+        """Capture body_count, overall bbox, and total mass of the design.
+
+        Best-effort — returns None if the design isn't readable yet.  Mass
+        is reported in grams; bbox in cm (Fusion's internal unit).
+        """
+        try:
+            design = self.app.activeProduct
+            if design is None or not hasattr(design, "rootComponent"):
+                return None
+            root = design.rootComponent
+
+            # Count bodies recursively (root + occurrences).
+            body_count = root.bRepBodies.count
+            try:
+                for occ in design.rootComponent.allOccurrences:
+                    body_count += occ.bRepBodies.count
+            except Exception:
+                pass  # allOccurrences can fail on empty designs
+
+            bbox_dict = None
+            if body_count > 0:
+                try:
+                    bbox = root.boundingBox
+                    if bbox is not None:
+                        bbox_dict = self._bbox_dict(bbox)
+                except Exception:
+                    bbox_dict = None
+
+            mass_g = 0.0
+            if body_count > 0:
+                try:
+                    # physicalProperties.mass is in kg
+                    mass_g = float(root.physicalProperties.mass) * 1000.0
+                except Exception:
+                    mass_g = 0.0
+
+            return {
+                "body_count": body_count,
+                "bbox": bbox_dict,
+                "mass_g": mass_g,
+            }
+        except Exception as exc:
+            log.debug("snapshot failed: %s", exc)
+            return None
+
+    @staticmethod
+    def _compute_deltas(before: dict, after: dict) -> dict:
+        """Return a diff suitable for an agent: counts + masses + bboxes."""
+        return {
+            "body_count_before": before.get("body_count", 0),
+            "body_count_after": after.get("body_count", 0),
+            "body_count_delta": after.get("body_count", 0)
+            - before.get("body_count", 0),
+            "mass_g_before": before.get("mass_g", 0.0),
+            "mass_g_after": after.get("mass_g", 0.0),
+            "mass_g_delta": after.get("mass_g", 0.0) - before.get("mass_g", 0.0),
+            "bbox_before": before.get("bbox"),
+            "bbox_after": after.get("bbox"),
+        }
+
+    # ------------------------------------------------------------------
+    # Viewport render (perception)
+    # ------------------------------------------------------------------
+
+    # Canonical named views in Fusion's coordinate system.
+    # Each entry: (eye_dx, eye_dy, eye_dz, up_x, up_y, up_z) relative to target.
+    _NAMED_VIEWS = {
+        "iso": (1.0, -1.0, 1.0, 0.0, 0.0, 1.0),
+        "front": (0.0, -1.0, 0.0, 0.0, 0.0, 1.0),
+        "back": (0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+        "top": (0.0, 0.0, 1.0, 0.0, 1.0, 0.0),
+        "bottom": (0.0, 0.0, -1.0, 0.0, 1.0, 0.0),
+        "left": (-1.0, 0.0, 0.0, 0.0, 0.0, 1.0),
+        "right": (1.0, 0.0, 0.0, 0.0, 0.0, 1.0),
+    }
+
+    def render_view(
+        self,
+        view: str = "current",
+        width: int = 1024,
+        height: int = 768,
+        fit: bool = True,
+    ):
+        """Save the active viewport to a PNG and return base64-encoded bytes.
+
+        * ``view`` — ``"current"`` keeps the existing camera, or one of
+          ``iso|front|back|top|bottom|left|right`` to reposition first.
+        * ``width``/``height`` — pixel dimensions.
+        * ``fit`` — call viewport.fit() before capture so the model frames.
+        """
+        viewport = self.app.activeViewport
+        if viewport is None:
+            raise RuntimeError("No active viewport")
+
+        if view != "current":
+            spec = self._NAMED_VIEWS.get(view)
+            if spec is None:
+                raise RuntimeError(
+                    f"Unknown view '{view}'. "
+                    f"Expected: current, {', '.join(self._NAMED_VIEWS)}"
+                )
+            self._orient_camera(viewport, spec)
+
+        if fit:
+            try:
+                viewport.fit()
+            except Exception:
+                pass  # fit() can fail on empty designs; keep going
+
+        # saveAsImageFile requires a real path; write to a tempfile.
+        fd, path = tempfile.mkstemp(suffix=".png", prefix="fusion_render_")
+        os.close(fd)
+        try:
+            ok = viewport.saveAsImageFile(path, int(width), int(height))
+            if not ok or not os.path.exists(path):
+                raise RuntimeError("saveAsImageFile returned false")
+            with open(path, "rb") as f:
+                data = f.read()
+        finally:
+            try:
+                os.remove(path)
+            except Exception:
+                pass
+
+        return {
+            "view": view,
+            "width": int(width),
+            "height": int(height),
+            "image_format": "png",
+            "image_base64": base64.b64encode(data).decode("ascii"),
+            "bytes": len(data),
+        }
+
+    def _orient_camera(self, viewport, spec):
+        """Position the camera at a canonical view relative to the model."""
+        design = self.app.activeProduct
+        root = design.rootComponent if design is not None else None
+
+        # Target is the model centroid (or origin if no bodies).
+        target = adsk.core.Point3D.create(0.0, 0.0, 0.0)
+        distance = 20.0
+        if root is not None and root.bRepBodies.count > 0:
+            try:
+                bbox = root.boundingBox
+                if bbox is not None:
+                    cx = (bbox.minPoint.x + bbox.maxPoint.x) * 0.5
+                    cy = (bbox.minPoint.y + bbox.maxPoint.y) * 0.5
+                    cz = (bbox.minPoint.z + bbox.maxPoint.z) * 0.5
+                    target = adsk.core.Point3D.create(cx, cy, cz)
+                    dx = bbox.maxPoint.x - bbox.minPoint.x
+                    dy = bbox.maxPoint.y - bbox.minPoint.y
+                    dz = bbox.maxPoint.z - bbox.minPoint.z
+                    distance = max(dx, dy, dz, 1.0) * 2.5
+            except Exception:
+                pass
+
+        eye = adsk.core.Point3D.create(
+            target.x + spec[0] * distance,
+            target.y + spec[1] * distance,
+            target.z + spec[2] * distance,
+        )
+        up = adsk.core.Vector3D.create(spec[3], spec[4], spec[5])
+
+        cam = viewport.camera
+        cam.eye = eye
+        cam.target = target
+        cam.upVector = up
+        cam.isSmoothTransition = False
+        viewport.camera = cam

--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -135,6 +135,9 @@ class CommandHandler:
                 "cam_post_process":     self.cam_post_process,
                 # health
                 "ping":                 self.ping,
+                # design type safety
+                "get_design_type":      self.get_design_type,
+                "set_design_type":      self.set_design_type,
             }
 
         cmd_type = command.get("type")
@@ -1121,11 +1124,31 @@ class CommandHandler:
         return {"deleted": True}
 
     def undo(self):
-        # Execute undo via UI command
+        design = self._design()
+        type_before = design.designType
+
         cmd_def = self.ui.commandDefinitions.itemById('UndoCommand')
         if cmd_def:
             cmd_def.execute()
-        return {"undone": True}
+
+        # Check if undo silently switched design type (Parametric → Direct)
+        adsk.doEvents()  # let Fusion process the undo
+        type_after = design.designType
+        if type_before != type_after:
+            # Undo the undo — redo to restore original state
+            redo_def = self.ui.commandDefinitions.itemById('RedoCommand')
+            if redo_def:
+                redo_def.execute()
+                adsk.doEvents()
+            raise RuntimeError(
+                f"Undo aborted: would have changed design type from "
+                f"{'Parametric' if type_before == 1 else 'Direct'} to "
+                f"{'Parametric' if type_after == 1 else 'Direct'}. "
+                f"The undo was automatically reversed (redo). "
+                f"Delete the failed feature explicitly instead."
+            )
+
+        return {"undone": True, "design_type": type_after}
 
     # ------------------------------------------------------------------
     # Direct Primitives (via TemporaryBRepManager)
@@ -1919,15 +1942,67 @@ class CommandHandler:
         return {"pong": True}
 
     # ------------------------------------------------------------------
+    # Design type safety
+    # ------------------------------------------------------------------
+
+    def get_design_type(self):
+        """Return current design type: 'parametric' or 'direct'."""
+        design = self._design()
+        dt = design.designType
+        return {
+            "design_type": "parametric" if dt == adsk.fusion.DesignTypes.ParametricDesignType else "direct",
+            "design_type_id": dt,
+        }
+
+    def set_design_type(self, design_type: str):
+        """Switch design type. Use 'parametric' to recover from accidental
+        direct-mode switches (equivalent to UI 'Capture Design History')."""
+        design = self._design()
+        current = design.designType
+
+        if design_type == "parametric":
+            target = adsk.fusion.DesignTypes.ParametricDesignType
+            if current == target:
+                return {"changed": False, "design_type": "parametric",
+                        "message": "Already in parametric mode"}
+            design.designType = target
+            adsk.doEvents()
+            # Verify it actually changed
+            if design.designType != target:
+                raise RuntimeError(
+                    "Failed to switch to parametric mode. "
+                    "Try 'Capture Design History' in the Fusion UI."
+                )
+            return {"changed": True, "design_type": "parametric"}
+
+        elif design_type == "direct":
+            target = adsk.fusion.DesignTypes.DirectDesignType
+            if current == target:
+                return {"changed": False, "design_type": "direct",
+                        "message": "Already in direct mode"}
+            design.designType = target
+            adsk.doEvents()
+            return {"changed": True, "design_type": "direct"}
+
+        else:
+            raise RuntimeError(
+                f"Invalid design_type '{design_type}'. "
+                f"Use 'parametric' or 'direct'."
+            )
+
+    # ------------------------------------------------------------------
     # Code execution (REPL-style)
     # ------------------------------------------------------------------
 
     def execute_code(self, code: str):
+        design = self._design()
+        type_before = design.designType
+
         ns = {
             "adsk": adsk,
             "app": self.app,
             "ui": self.ui,
-            "design": self._design(),
+            "design": design,
             "component": self._root(),
             "math": math,
         }
@@ -1956,6 +2031,18 @@ class CommandHandler:
 
         output = buf.getvalue()
         result = last_expr_value if last_expr_value is not None else output
+
+        # Warn if design type changed during execution
+        type_after = design.designType
+        design_type_warning = None
+        if type_before != type_after:
+            design_type_warning = (
+                f"WARNING: Design type changed from "
+                f"{'parametric' if type_before == 1 else 'direct'} to "
+                f"{'parametric' if type_after == 1 else 'direct'} "
+                f"during code execution. Use set_design_type to recover."
+            )
+            log.warning(design_type_warning)
         if result is not None:
             try:
                 import json as _json
@@ -1963,7 +2050,10 @@ class CommandHandler:
             except (TypeError, ValueError):
                 result = str(result)
 
-        return {"executed": True, "result": result, "output": output}
+        response = {"executed": True, "result": result, "output": output}
+        if design_type_warning:
+            response["design_type_warning"] = design_type_warning
+        return response
 
     # ------------------------------------------------------------------
     # Camera helper

--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -39,6 +39,21 @@ class CommandHandler:
 
     _COMMANDS = None  # populated lazily
 
+    # Canonical camera presets, (eye_dir, up_vec) in Fusion's Z-up world.
+    # Shared by render_view and export_view_sheet.
+    _VIEW_DIRS = {
+        "iso": ((1.0, -1.0, 1.0), (0.0, 0.0, 1.0)),
+        "iso_ne": ((1.0, 1.0, 1.0), (0.0, 0.0, 1.0)),
+        "iso_nw": ((-1.0, 1.0, 1.0), (0.0, 0.0, 1.0)),
+        "iso_sw": ((-1.0, -1.0, 1.0), (0.0, 0.0, 1.0)),
+        "front": ((0.0, -1.0, 0.0), (0.0, 0.0, 1.0)),
+        "back": ((0.0, 1.0, 0.0), (0.0, 0.0, 1.0)),
+        "top": ((0.0, 0.0, 1.0), (0.0, 1.0, 0.0)),
+        "bottom": ((0.0, 0.0, -1.0), (0.0, 1.0, 0.0)),
+        "right": ((1.0, 0.0, 0.0), (0.0, 0.0, 1.0)),
+        "left": ((-1.0, 0.0, 0.0), (0.0, 0.0, 1.0)),
+    }
+
     # Commands that can change body mass / bbox / body count.  Only these
     # get before/after snapshots so agents can sanity-check without a render.
     _MUTATION_COMMANDS = frozenset(
@@ -1426,20 +1441,6 @@ class CommandHandler:
     # Render canonical views (iso/front/top/right/...) as PNGs and emit
     # a self-contained HTML page suitable for print-to-PDF. Intended
     # audience: mechanical engineers who want a quick sense of the part.
-
-    # Unit vectors per view: (eye_dir, up). Fusion's world is Z-up.
-    _VIEW_DIRS = {
-        "iso": ((1.0, -1.0, 1.0), (0.0, 0.0, 1.0)),
-        "iso_ne": ((1.0, 1.0, 1.0), (0.0, 0.0, 1.0)),
-        "iso_nw": ((-1.0, 1.0, 1.0), (0.0, 0.0, 1.0)),
-        "iso_sw": ((-1.0, -1.0, 1.0), (0.0, 0.0, 1.0)),
-        "front": ((0.0, -1.0, 0.0), (0.0, 0.0, 1.0)),
-        "back": ((0.0, 1.0, 0.0), (0.0, 0.0, 1.0)),
-        "top": ((0.0, 0.0, 1.0), (0.0, 1.0, 0.0)),
-        "bottom": ((0.0, 0.0, -1.0), (0.0, 1.0, 0.0)),
-        "right": ((1.0, 0.0, 0.0), (0.0, 0.0, 1.0)),
-        "left": ((-1.0, 0.0, 0.0), (0.0, 0.0, 1.0)),
-    }
 
     def _scene_center_and_radius(self):
         """Return (center, radius) covering all visible root bodies."""
@@ -2851,18 +2852,6 @@ class CommandHandler:
     # Viewport render (perception)
     # ------------------------------------------------------------------
 
-    # Canonical named views in Fusion's coordinate system.
-    # Each entry: (eye_dx, eye_dy, eye_dz, up_x, up_y, up_z) relative to target.
-    _NAMED_VIEWS = {
-        "iso": (1.0, -1.0, 1.0, 0.0, 0.0, 1.0),
-        "front": (0.0, -1.0, 0.0, 0.0, 0.0, 1.0),
-        "back": (0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-        "top": (0.0, 0.0, 1.0, 0.0, 1.0, 0.0),
-        "bottom": (0.0, 0.0, -1.0, 0.0, 1.0, 0.0),
-        "left": (-1.0, 0.0, 0.0, 0.0, 0.0, 1.0),
-        "right": (1.0, 0.0, 0.0, 0.0, 0.0, 1.0),
-    }
-
     def render_view(
         self,
         view: str = "current",
@@ -2873,43 +2862,64 @@ class CommandHandler:
         """Save the active viewport to a PNG and return base64-encoded bytes.
 
         * ``view`` — ``"current"`` keeps the existing camera, or one of
-          ``iso|front|back|top|bottom|left|right`` to reposition first.
+          ``_VIEW_DIRS`` keys (iso, front, top, ...) to reposition first.
         * ``width``/``height`` — pixel dimensions.
         * ``fit`` — call viewport.fit() before capture so the model frames.
+
+        If ``view != "current"``, the camera is restored to its prior state
+        before returning so the user's view isn't disturbed.
         """
         viewport = self.app.activeViewport
         if viewport is None:
             raise RuntimeError("No active viewport")
 
-        if view != "current":
-            spec = self._NAMED_VIEWS.get(view)
+        repositioned = view != "current"
+        if repositioned:
+            spec = self._VIEW_DIRS.get(view)
             if spec is None:
                 raise RuntimeError(
                     f"Unknown view '{view}'. "
-                    f"Expected: current, {', '.join(self._NAMED_VIEWS)}"
+                    f"Expected: current, {', '.join(self._VIEW_DIRS)}"
                 )
+            orig = viewport.camera
+            orig_state = {
+                "eye": (orig.eye.x, orig.eye.y, orig.eye.z),
+                "target": (orig.target.x, orig.target.y, orig.target.z),
+                "up": (orig.upVector.x, orig.upVector.y, orig.upVector.z),
+                "type": orig.cameraType,
+            }
             self._orient_camera(viewport, spec)
 
-        if fit:
-            try:
-                viewport.fit()
-            except Exception:
-                pass  # fit() can fail on empty designs; keep going
-
-        # saveAsImageFile requires a real path; write to a tempfile.
-        fd, path = tempfile.mkstemp(suffix=".png", prefix="fusion_render_")
-        os.close(fd)
         try:
-            ok = viewport.saveAsImageFile(path, int(width), int(height))
-            if not ok or not os.path.exists(path):
-                raise RuntimeError("saveAsImageFile returned false")
-            with open(path, "rb") as f:
-                data = f.read()
-        finally:
+            if fit:
+                try:
+                    viewport.fit()
+                except Exception:
+                    pass  # fit() can fail on empty designs; keep going
+
+            # saveAsImageFile requires a real path; write to a tempfile.
+            fd, path = tempfile.mkstemp(suffix=".png", prefix="fusion_render_")
+            os.close(fd)
             try:
-                os.remove(path)
-            except Exception:
-                pass
+                ok = viewport.saveAsImageFile(path, int(width), int(height))
+                if not ok or not os.path.exists(path):
+                    raise RuntimeError("saveAsImageFile returned false")
+                with open(path, "rb") as f:
+                    data = f.read()
+            finally:
+                try:
+                    os.remove(path)
+                except Exception:
+                    pass
+        finally:
+            if repositioned:
+                cam = viewport.camera
+                cam.isSmoothTransition = False
+                cam.cameraType = orig_state["type"]
+                cam.eye = adsk.core.Point3D.create(*orig_state["eye"])
+                cam.target = adsk.core.Point3D.create(*orig_state["target"])
+                cam.upVector = adsk.core.Vector3D.create(*orig_state["up"])
+                viewport.camera = cam
 
         return {
             "view": view,
@@ -2921,7 +2931,11 @@ class CommandHandler:
         }
 
     def _orient_camera(self, viewport, spec):
-        """Position the camera at a canonical view relative to the model."""
+        """Position the camera at a canonical view relative to the model.
+
+        ``spec`` is ``(eye_dir, up_vec)`` from ``_VIEW_DIRS``.
+        """
+        eye_dir, up_vec = spec
         design = self.app.activeProduct
         root = design.rootComponent if design is not None else None
 
@@ -2944,11 +2958,11 @@ class CommandHandler:
                 pass
 
         eye = adsk.core.Point3D.create(
-            target.x + spec[0] * distance,
-            target.y + spec[1] * distance,
-            target.z + spec[2] * distance,
+            target.x + eye_dir[0] * distance,
+            target.y + eye_dir[1] * distance,
+            target.z + eye_dir[2] * distance,
         )
-        up = adsk.core.Vector3D.create(spec[3], spec[4], spec[5])
+        up = adsk.core.Vector3D.create(up_vec[0], up_vec[1], up_vec[2])
 
         cam = viewport.camera
         cam.eye = eye

--- a/addon/server/hints.py
+++ b/addon/server/hints.py
@@ -1,0 +1,138 @@
+"""
+Error classification for Fusion API failures.
+
+Maps exception messages from the Fusion API (and our handler code) to a
+stable ``error_kind`` tag plus a small list of contextual repair hints.
+
+Keep this file in sync with ``src/fusion360_mcp/hints.py`` — the addon
+is installed into Fusion's AddIns folder at deploy time and cannot import
+from the MCP server package.
+"""
+
+import re
+
+# Each entry: (regex applied to str(exc), error_kind, hints)
+# First match wins. Patterns use re.IGNORECASE.
+_RULES: list[tuple[str, str, list[str]]] = [
+    (
+        r"no active design",
+        "NO_ACTIVE_DESIGN",
+        [
+            "Open or create a design in Fusion before calling mutation tools.",
+            "Use get_design_type to confirm the active product is a design.",
+        ],
+    ),
+    (
+        r"no profiles? in sketch",
+        "PROFILE_NOT_CLOSED",
+        [
+            "The sketch has no closed profile to extrude/revolve.",
+            "Check that your curves form a closed loop — draw_line segments "
+            "must share endpoints exactly (use add_constraint coincident).",
+            "Inspect the sketch with get_scene_info — a sketch with 0 profiles "
+            "is never extrudable.",
+        ],
+    ),
+    (
+        r"sketch\b.*\bnot found|no sketch|sketch.*does not exist",
+        "SKETCH_NOT_FOUND",
+        [
+            "The named sketch does not exist in the active design.",
+            "List sketches via get_scene_info before referencing one by name.",
+        ],
+    ),
+    (
+        r"body\b.*\bnot found|no body|body.*does not exist",
+        "BODY_NOT_FOUND",
+        [
+            "The named body does not exist in the active design.",
+            "Use list_components or get_scene_info to see available bodies.",
+        ],
+    ),
+    (
+        r"self[- ]?intersect",
+        "SELF_INTERSECTION",
+        [
+            "The resulting geometry self-intersects — Fusion cannot resolve it.",
+            "For sweeps: check the path curvature vs. the profile size.",
+            "For lofts: ensure profiles are oriented consistently.",
+            "Try reducing the feature size, or split into smaller operations.",
+        ],
+    ),
+    (
+        r"regenerat(e|ion) fail|feature\s+fail(ed|ure)|rebuild fail",
+        "REGEN_FAILED",
+        [
+            "Fusion could not regenerate the feature with these inputs.",
+            "Check for references to deleted geometry upstream in the timeline.",
+            "Try undo, then attempt the mutation with different parameters.",
+        ],
+    ),
+    (
+        r"boolean.*(empty|no[- ]?op|no result|failed)|subtract.*empty",
+        "BOOLEAN_NO_OP",
+        [
+            "Boolean operation produced no change — tool and target do not "
+            "intersect, or the result would be identical to the target.",
+            "Verify the tool body actually overlaps the target — use "
+            "check_interference.",
+            "For subtract: confirm the tool body is inside or crosses the target.",
+            "Consider move_body to reposition before retrying.",
+        ],
+    ),
+    (
+        r"invalid (argument|input|parameter)|bad (argument|input|value)",
+        "INVALID_INPUT",
+        [
+            "Fusion rejected one of the parameters.",
+            "Check units (all Fusion API values are in cm), enum values, and "
+            "that referenced entities still exist.",
+        ],
+    ),
+    (
+        r"unknown command",
+        "UNKNOWN_COMMAND",
+        [
+            "The add-in does not know this command — typo or version skew.",
+            "Restart the addon (via reload_handler) if you recently added tools.",
+        ],
+    ),
+    (
+        r"profile.*(open|not closed|unclosed)",
+        "PROFILE_NOT_CLOSED",
+        [
+            "The profile is open — extrude/revolve need a closed loop.",
+            "Draw the missing segment or add coincident constraints at endpoints.",
+        ],
+    ),
+    (
+        r"timeout",
+        "TIMEOUT",
+        [
+            "The operation exceeded the 30s bridge timeout.",
+            "If a long operation is expected (CAM toolpath, complex fillet), "
+            "split it into smaller steps.",
+        ],
+    ),
+    (
+        r"parametric|direct[- ]edit",
+        "DESIGN_TYPE_MISMATCH",
+        [
+            "This operation is not permitted in the current design type.",
+            "Check get_design_type; some operations (like undo after direct "
+            "edits) require parametric mode.",
+        ],
+    ),
+]
+
+
+def classify(exc: BaseException) -> tuple[str, list[str]]:
+    """Return ``(error_kind, hints)`` for *exc*.
+
+    Falls back to ``("UNKNOWN", [])`` if no rule matches.
+    """
+    msg = str(exc) or exc.__class__.__name__
+    for pattern, kind, hints in _RULES:
+        if re.search(pattern, msg, re.IGNORECASE):
+            return kind, list(hints)
+    return "UNKNOWN", []

--- a/addon/server/hints.py
+++ b/addon/server/hints.py
@@ -115,7 +115,9 @@ _RULES: list[tuple[str, str, list[str]]] = [
         ],
     ),
     (
-        r"parametric|direct[- ]edit",
+        r"requires (?:parametric|direct[- ]edit)|"
+        r"not (?:supported|permitted|allowed) in (?:parametric|direct[- ]edit)|"
+        r"switch to (?:parametric|direct[- ]edit)",
         "DESIGN_TYPE_MISMATCH",
         [
             "This operation is not permitted in the current design type.",

--- a/scripts/smoke_envelope.py
+++ b/scripts/smoke_envelope.py
@@ -1,0 +1,54 @@
+"""Mock-mode smoke test: print the new envelope shapes end-to-end."""
+
+import json
+
+from fusion360_mcp.mock import mock_command
+from fusion360_mcp.server import _format_result
+
+
+def dump(label, name, params=None):
+    print(f"\n=== {label} ===")
+    result = mock_command(name, params or {})
+    print("RAW RESULT:")
+    print(
+        json.dumps(
+            {
+                k: (f"<{len(v)} b64 chars>" if k == "image_base64" else v)
+                for k, v in result.items()
+            },
+            indent=2,
+            default=str,
+        )
+    )
+
+    formatted = _format_result(name, result)
+    print("\nFORMATTED (what the agent sees):")
+    if hasattr(formatted, "content"):
+        is_err = getattr(formatted, "isError", False)
+        print(f"[isError={is_err}]")
+        for block in formatted.content:
+            print(block.text)
+    else:
+        for block in formatted:
+            if block.type == "text":
+                print(block.text)
+            elif block.type == "image":
+                print(f"<IMAGE BLOCK: {block.mimeType}, {len(block.data)} b64 chars>")
+
+
+dump("1. SUCCESS with deltas (extrude)", "extrude", {"height": 3.0})
+dump(
+    "2. STRUCTURED ERROR with hints (forced)",
+    "extrude",
+    {"height": 3.0, "__mock_error__": "No profiles in sketch"},
+)
+dump("3. RENDER_VIEW image content", "render_view", {"view": "iso"})
+dump(
+    "4. NO-OP boolean (simulated)",
+    "boolean_operation",
+    {
+        "target_body": "Body1",
+        "tool_body": "Body2",
+        "__mock_error__": "Boolean subtract failed — empty result",
+    },
+)

--- a/src/fusion360_mcp/hints.py
+++ b/src/fusion360_mcp/hints.py
@@ -112,7 +112,9 @@ _RULES: list[tuple[str, str, list[str]]] = [
         ],
     ),
     (
-        r"parametric|direct[- ]edit",
+        r"requires (?:parametric|direct[- ]edit)|"
+        r"not (?:supported|permitted|allowed) in (?:parametric|direct[- ]edit)|"
+        r"switch to (?:parametric|direct[- ]edit)",
         "DESIGN_TYPE_MISMATCH",
         [
             "This operation is not permitted in the current design type.",

--- a/src/fusion360_mcp/hints.py
+++ b/src/fusion360_mcp/hints.py
@@ -1,0 +1,139 @@
+"""
+Error classification for Fusion API failures (mirror of addon copy).
+
+This module is used in mock mode and in tests.  The canonical table lives
+in ``addon/server/hints.py`` because the addon is installed into Fusion's
+AddIns folder and cannot import from this package.  Keep them in sync.
+"""
+
+import re
+
+# Each entry: (regex applied to str(exc), error_kind, hints)
+# First match wins. Patterns use re.IGNORECASE.
+_RULES: list[tuple[str, str, list[str]]] = [
+    (
+        r"no active design",
+        "NO_ACTIVE_DESIGN",
+        [
+            "Open or create a design in Fusion before calling mutation tools.",
+            "Use get_design_type to confirm the active product is a design.",
+        ],
+    ),
+    (
+        r"no profiles? in sketch",
+        "PROFILE_NOT_CLOSED",
+        [
+            "The sketch has no closed profile to extrude/revolve.",
+            "Check that your curves form a closed loop — draw_line segments "
+            "must share endpoints exactly (use add_constraint coincident).",
+            "Inspect the sketch with get_scene_info — a sketch with 0 profiles "
+            "is never extrudable.",
+        ],
+    ),
+    (
+        r"sketch\b.*\bnot found|no sketch|sketch.*does not exist",
+        "SKETCH_NOT_FOUND",
+        [
+            "The named sketch does not exist in the active design.",
+            "List sketches via get_scene_info before referencing one by name.",
+        ],
+    ),
+    (
+        r"body\b.*\bnot found|no body|body.*does not exist",
+        "BODY_NOT_FOUND",
+        [
+            "The named body does not exist in the active design.",
+            "Use list_components or get_scene_info to see available bodies.",
+        ],
+    ),
+    (
+        r"self[- ]?intersect",
+        "SELF_INTERSECTION",
+        [
+            "The resulting geometry self-intersects — Fusion cannot resolve it.",
+            "For sweeps: check the path curvature vs. the profile size.",
+            "For lofts: ensure profiles are oriented consistently.",
+            "Try reducing the feature size, or split into smaller operations.",
+        ],
+    ),
+    (
+        r"regenerat(e|ion) fail|feature\s+fail(ed|ure)|rebuild fail",
+        "REGEN_FAILED",
+        [
+            "Fusion could not regenerate the feature with these inputs.",
+            "Check for references to deleted geometry upstream in the timeline.",
+            "Try undo, then attempt the mutation with different parameters.",
+        ],
+    ),
+    (
+        r"boolean.*(empty|no[- ]?op|no result|failed)|subtract.*empty",
+        "BOOLEAN_NO_OP",
+        [
+            "Boolean operation produced no change — tool and target do not "
+            "intersect, or the result would be identical to the target.",
+            "Verify the tool body actually overlaps the target — use "
+            "check_interference.",
+            "For subtract: confirm the tool body is inside or crosses the target.",
+            "Consider move_body to reposition before retrying.",
+        ],
+    ),
+    (
+        r"invalid (argument|input|parameter)|bad (argument|input|value)",
+        "INVALID_INPUT",
+        [
+            "Fusion rejected one of the parameters.",
+            "Check units (all Fusion API values are in cm), enum values, and "
+            "that referenced entities still exist.",
+        ],
+    ),
+    (
+        r"unknown command",
+        "UNKNOWN_COMMAND",
+        [
+            "The add-in does not know this command — typo or version skew.",
+            "Restart the addon (via reload_handler) if you recently added tools.",
+        ],
+    ),
+    (
+        r"profile.*(open|not closed|unclosed)",
+        "PROFILE_NOT_CLOSED",
+        [
+            "The profile is open — extrude/revolve need a closed loop.",
+            "Draw the missing segment or add coincident constraints at endpoints.",
+        ],
+    ),
+    (
+        r"timeout",
+        "TIMEOUT",
+        [
+            "The operation exceeded the 30s bridge timeout.",
+            "If a long operation is expected (CAM toolpath, complex fillet), "
+            "split it into smaller steps.",
+        ],
+    ),
+    (
+        r"parametric|direct[- ]edit",
+        "DESIGN_TYPE_MISMATCH",
+        [
+            "This operation is not permitted in the current design type.",
+            "Check get_design_type; some operations (like undo after direct "
+            "edits) require parametric mode.",
+        ],
+    ),
+]
+
+
+def classify(exc: BaseException | str) -> tuple[str, list[str]]:
+    """Return ``(error_kind, hints)`` for *exc*.
+
+    Accepts either an exception or a message string.  Falls back to
+    ``("UNKNOWN", [])`` if no rule matches.
+    """
+    if isinstance(exc, BaseException):
+        msg = str(exc) or exc.__class__.__name__
+    else:
+        msg = str(exc)
+    for pattern, kind, hints in _RULES:
+        if re.search(pattern, msg, re.IGNORECASE):
+            return kind, list(hints)
+    return "UNKNOWN", []

--- a/src/fusion360_mcp/mock.py
+++ b/src/fusion360_mcp/mock.py
@@ -140,11 +140,22 @@ def _delete_all(_p: dict) -> dict:
 
 
 def _undo(_p: dict) -> dict:
-    return {"undone": True}
+    return {"undone": True, "design_type": 1}
 
 
 def _execute_code(p: dict) -> dict:
-    return {"code": p.get("code", ""), "result": "None"}
+    return {"executed": True, "code": p.get("code", ""), "result": "None", "output": ""}
+
+
+# ── design type safety ───────────────────────────────────────────────
+
+def _get_design_type(_p: dict) -> dict:
+    return {"design_type": "parametric", "design_type_id": 1}
+
+
+def _set_design_type(p: dict) -> dict:
+    dt = p.get("design_type", "parametric")
+    return {"changed": True, "design_type": dt}
 
 
 # ── new geometry tools ────────────────────────────────────────────────
@@ -796,4 +807,7 @@ _DISPATCH: dict[str, Any] = {
     "cam_list_setups": _cam_list_setups,
     "cam_list_operations": _cam_list_operations,
     "cam_get_operation_info": _cam_get_operation_info,
+    # design type safety
+    "get_design_type": _get_design_type,
+    "set_design_type": _set_design_type,
 }

--- a/src/fusion360_mcp/mock.py
+++ b/src/fusion360_mcp/mock.py
@@ -4,21 +4,105 @@ Mock responses for every Fusion 360 MCP command.
 Used when the server is started with ``--mode mock`` so the full
 tool→response pipeline can be tested without a running Fusion instance.
 Every response includes ``"mode": "mock"`` so callers know it's simulated.
+
+The envelope matches the real addon: success results carry ``ok: True``,
+mutation results carry a ``deltas`` sub-dict, and an ``__mock_error__``
+sentinel in params forces a classified error response for tests.
 """
 
 from typing import Any
 
+from .hints import classify as _classify
+
+# Mutation commands that get a synthetic deltas payload in mock mode.
+# Keep in sync with CommandHandler._MUTATION_COMMANDS in the addon.
+_MUTATION_MOCKS: frozenset[str] = frozenset(
+    {
+        "extrude",
+        "revolve",
+        "sweep",
+        "loft",
+        "fillet",
+        "chamfer",
+        "shell",
+        "mirror",
+        "create_hole",
+        "rectangular_pattern",
+        "circular_pattern",
+        "create_thread",
+        "draft_faces",
+        "split_body",
+        "split_face",
+        "offset_faces",
+        "scale_body",
+        "suppress_feature",
+        "unsuppress_feature",
+        "move_body",
+        "boolean_operation",
+        "create_box",
+        "create_cylinder",
+        "create_sphere",
+        "create_torus",
+        "thicken_surface",
+        "patch_surface",
+        "stitch_surfaces",
+        "ruled_surface",
+        "trim_surface",
+        "create_flange",
+        "create_bend",
+        "flat_pattern",
+        "unfold",
+        "delete_all",
+        "undo",
+        "set_parameter",
+        "execute_code",
+    }
+)
+
+_MOCK_DELTAS = {
+    "body_count_before": 0,
+    "body_count_after": 1,
+    "body_count_delta": 1,
+    "mass_g_before": 0.0,
+    "mass_g_after": 10.0,
+    "mass_g_delta": 10.0,
+    "bbox_before": None,
+    "bbox_after": {"min": [0.0, 0.0, 0.0], "max": [1.0, 1.0, 1.0]},
+}
+
 
 def mock_command(command_type: str, params: dict[str, Any] | None = None) -> dict:
-    """Return a plausible mock response for *command_type*."""
+    """Return a plausible mock response for *command_type*.
+
+    If *params* contains ``__mock_error__`` (a string message), the response
+    simulates an addon-side failure: ``ok: False`` plus a classified
+    ``error_kind`` and contextual ``hints``.
+    """
     params = params or {}
+
+    forced = params.get("__mock_error__")
+    if forced is not None:
+        kind, hint_list = _classify(str(forced))
+        return {
+            "ok": False,
+            "error_kind": kind,
+            "error_message": str(forced),
+            "hints": hint_list,
+            "traceback": f"MockError: {forced}",
+            "mode": "mock",
+        }
+
     handler = _DISPATCH.get(command_type, _default_mock)
     result = handler(params)
+    result.setdefault("ok", True)
+    if command_type in _MUTATION_MOCKS and "deltas" not in result:
+        result["deltas"] = dict(_MOCK_DELTAS)
     result["mode"] = "mock"
     return result
 
 
 # ── individual mock handlers ──────────────────────────────────────────
+
 
 def _ping(_p: dict) -> dict:
     return {"status": "pong"}
@@ -149,6 +233,7 @@ def _execute_code(p: dict) -> dict:
 
 # ── design type safety ───────────────────────────────────────────────
 
+
 def _get_design_type(_p: dict) -> dict:
     return {"design_type": "parametric", "design_type_id": 1}
 
@@ -159,6 +244,7 @@ def _set_design_type(p: dict) -> dict:
 
 
 # ── new geometry tools ────────────────────────────────────────────────
+
 
 def _sweep(p: dict) -> dict:
     return {
@@ -220,6 +306,7 @@ def _circular_pattern(p: dict) -> dict:
 
 # ── assembly tools ────────────────────────────────────────────────────
 
+
 def _create_component(p: dict) -> dict:
     return {
         "component_name": p.get("name", "Component1"),
@@ -247,6 +334,7 @@ def _list_components(_p: dict) -> dict:
 
 # ── export tools ──────────────────────────────────────────────────────
 
+
 def _export_step(p: dict) -> dict:
     name = p.get("body_name", "Body1")
     path = p.get("file_path", f"~/Desktop/{name}.step")
@@ -259,6 +347,7 @@ def _export_f3d(p: dict) -> dict:
 
 
 # ── parameter tools ───────────────────────────────────────────────────
+
 
 def _get_parameters(_p: dict) -> dict:
     return {
@@ -288,6 +377,7 @@ def _delete_parameter(p: dict) -> dict:
 
 # ── sketch constraints & dimensions ───────────────────────────────────
 
+
 def _add_constraint(p: dict) -> dict:
     return {
         "constraint_type": p.get("constraint_type", "coincident"),
@@ -308,6 +398,7 @@ def _add_dimension(p: dict) -> dict:
 
 # ── construction geometry ─────────────────────────────────────────────
 
+
 def _create_construction_plane(p: dict) -> dict:
     return {
         "plane_name": "ConstructionPlane_mock",
@@ -324,6 +415,7 @@ def _create_construction_axis(p: dict) -> dict:
 
 # ── splines ───────────────────────────────────────────────────────────
 
+
 def _draw_spline(p: dict) -> dict:
     return {
         "sketch_name": "Sketch_mock_xy",
@@ -333,6 +425,7 @@ def _draw_spline(p: dict) -> dict:
 
 
 # ── sketch curve operations ──────────────────────────────────────────
+
 
 def _offset_curve(p: dict) -> dict:
     return {
@@ -360,14 +453,13 @@ def _extend_curve(p: dict) -> dict:
 
 # ── advanced features ─────────────────────────────────────────────────
 
+
 def _create_thread(p: dict) -> dict:
     return {
         "body_name": p.get("body_name", "Body1"),
         "face_index": p.get("face_index", 0),
         "is_modeled": p.get("is_modeled", False),
-        "thread_designation": p.get(
-            "thread_designation", "M10x1.5"
-        ),
+        "thread_designation": p.get("thread_designation", "M10x1.5"),
     }
 
 
@@ -409,6 +501,7 @@ def _scale_body(p: dict) -> dict:
 
 # ── direct primitives ────────────────────────────────────────────────
 
+
 def _create_box(p: dict) -> dict:
     return {
         "body_name": "Box_mock",
@@ -443,6 +536,7 @@ def _create_torus(p: dict) -> dict:
 
 # ── assembly (extended) ──────────────────────────────────────────────
 
+
 def _create_as_built_joint(p: dict) -> dict:
     return {
         "component_one": p.get("component_one", "Comp1"),
@@ -460,6 +554,7 @@ def _create_rigid_group(p: dict) -> dict:
 
 
 # ── inspection / analysis ────────────────────────────────────────────
+
 
 def _measure_distance(p: dict) -> dict:
     return {
@@ -508,17 +603,17 @@ def _check_interference(p: dict) -> dict:
 
 # ── appearance ────────────────────────────────────────────────────────
 
+
 def _set_appearance(p: dict) -> dict:
     return {
         "target_name": p.get("target_name", "Body1"),
-        "appearance_name": p.get(
-            "appearance_name", "Steel - Satin"
-        ),
+        "appearance_name": p.get("appearance_name", "Steel - Satin"),
         "applied": True,
     }
 
 
 # ── project geometry ─────────────────────────────────────────────────
+
 
 def _project_geometry(p: dict) -> dict:
     return {
@@ -529,6 +624,7 @@ def _project_geometry(p: dict) -> dict:
 
 
 # ── timeline control ─────────────────────────────────────────────────
+
 
 def _suppress_feature(p: dict) -> dict:
     return {
@@ -545,6 +641,7 @@ def _unsuppress_feature(p: dict) -> dict:
 
 
 # ── surface operations ──────────────────────────────────────────────
+
 
 def _patch_surface(p: dict) -> dict:
     return {
@@ -589,6 +686,7 @@ def _trim_surface(p: dict) -> dict:
 
 # ── sheet metal ─────────────────────────────────────────────────────
 
+
 def _create_flange(p: dict) -> dict:
     return {
         "body_name": p.get("body_name", "SheetBody1"),
@@ -621,6 +719,7 @@ def _unfold(p: dict) -> dict:
 
 
 # ── CAM / manufacturing ─────────────────────────────────────────────
+
 
 def _cam_create_setup(p: dict) -> dict:
     return {
@@ -704,7 +803,28 @@ def _cam_get_operation_info(p: dict) -> dict:
     }
 
 
+# ── perception (viewport render) ─────────────────────────────────────
+
+# 1x1 transparent PNG, enough to exercise the image-content code path.
+_MOCK_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0l"
+    "EQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII="
+)
+
+
+def _render_view(p: dict) -> dict:
+    return {
+        "view": p.get("view", "current"),
+        "width": int(p.get("width", 1024)),
+        "height": int(p.get("height", 768)),
+        "image_format": "png",
+        "image_base64": _MOCK_PNG_B64,
+        "bytes": len(_MOCK_PNG_B64),
+    }
+
+
 # ── default fallback ─────────────────────────────────────────────────
+
 
 def _default_mock(p: dict) -> dict:
     return {"warning": "no mock handler for this command", "params_received": p}
@@ -810,4 +930,6 @@ _DISPATCH: dict[str, Any] = {
     # design type safety
     "get_design_type": _get_design_type,
     "set_design_type": _set_design_type,
+    # perception
+    "render_view": _render_view,
 }

--- a/src/fusion360_mcp/server.py
+++ b/src/fusion360_mcp/server.py
@@ -18,8 +18,9 @@ from .connection import get_connection, reset_connection
 from .mock import mock_command
 from .tools import get_tool_by_name, get_tool_list
 
-logging.basicConfig(level=logging.INFO,
-                    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+)
 log = logging.getLogger("fusion360_mcp.server")
 
 
@@ -37,12 +38,113 @@ def _send(
     return conn.send_command(command_type, params)
 
 
+# Fields surfaced at the top of the formatted text block.  Everything else
+# in the result dict is rendered below as ``key: value`` pairs.
+_SPECIAL_KEYS = {
+    "ok",
+    "error_kind",
+    "error_message",
+    "hints",
+    "traceback",
+    "deltas",
+    "image_base64",
+}
+
+
+def _format_deltas(deltas: dict) -> list[str]:
+    """Render the deltas sub-dict as indented bullet lines."""
+    lines = ["  deltas:"]
+    bc_before = deltas.get("body_count_before")
+    bc_after = deltas.get("body_count_after")
+    bc_delta = deltas.get("body_count_delta")
+    if bc_before is not None or bc_after is not None:
+        lines.append(f"    body_count: {bc_before} → {bc_after} (Δ{bc_delta:+d})")
+    mg_before = deltas.get("mass_g_before")
+    mg_after = deltas.get("mass_g_after")
+    mg_delta = deltas.get("mass_g_delta")
+    if mg_delta is not None:
+        lines.append(
+            f"    mass_g:     {mg_before:.3f} → {mg_after:.3f} (Δ{mg_delta:+.3f})"
+        )
+    if deltas.get("bbox_before") is not None:
+        lines.append(f"    bbox_before: {deltas['bbox_before']}")
+    if deltas.get("bbox_after") is not None:
+        lines.append(f"    bbox_after:  {deltas['bbox_after']}")
+    return lines
+
+
+def _format_result(
+    name: str,
+    result: dict | object,
+) -> list[types.ContentBlock] | types.CallToolResult:
+    """Render an addon/mock result into MCP content blocks.
+
+    * Error responses (``ok: False``) → text block with hints + isError=True.
+    * ``render_view`` success → text metadata + ImageContent for the PNG.
+    * Everything else → text block listing result fields (+ deltas if any).
+    """
+    # Non-dict fallback (shouldn't happen, but stay robust).
+    if not isinstance(result, dict):
+        return [types.TextContent(type="text", text=f"**{name}** OK\n  {result}")]
+
+    # Error path (application-level failure classified by the addon).
+    if result.get("ok") is False:
+        lines = [
+            f"**{name}** ERROR ({result.get('error_kind', 'UNKNOWN')})",
+            f"  {result.get('error_message', '(no message)')}",
+        ]
+        hints = result.get("hints") or []
+        if hints:
+            lines.append("  hints:")
+            lines.extend(f"    - {h}" for h in hints)
+        tb = result.get("traceback")
+        if tb:
+            lines.append("")
+            lines.append("traceback:")
+            lines.append(tb)
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text="\n".join(lines))],
+            isError=True,
+        )
+
+    # Success path.
+    lines = [f"**{name}** OK"]
+    for k, v in result.items():
+        if k in _SPECIAL_KEYS:
+            continue
+        lines.append(f"  {k}: {v}")
+    deltas = result.get("deltas")
+    if isinstance(deltas, dict):
+        lines.extend(_format_deltas(deltas))
+
+    content: list[types.ContentBlock] = [
+        types.TextContent(type="text", text="\n".join(lines)),
+    ]
+
+    # render_view: attach the PNG as an image block so vision models can see it.
+    image_b64 = result.get("image_base64")
+    if isinstance(image_b64, str) and image_b64:
+        img_format = result.get("image_format", "png")
+        content.append(
+            types.ImageContent(
+                type="image",
+                data=image_b64,
+                mimeType=f"image/{img_format}",
+            )
+        )
+    return content
+
+
 @click.command()
-@click.option("--mode", type=click.Choice(["socket", "mock"]),
-              default="socket",
-              help="'socket' connects to Fusion, 'mock' returns test data")
-@click.option("--port", type=int, default=9876,
-              help="TCP port the Fusion 360 add-in listens on")
+@click.option(
+    "--mode",
+    type=click.Choice(["socket", "mock"]),
+    default="socket",
+    help="'socket' connects to Fusion, 'mock' returns test data",
+)
+@click.option(
+    "--port", type=int, default=9876, help="TCP port the Fusion 360 add-in listens on"
+)
 def main(mode: str, port: int) -> int:
     """Fusion360 MCP Server — connects Claude to Fusion 360."""
 
@@ -56,7 +158,8 @@ def main(mode: str, port: int) -> int:
 
     @app.call_tool()
     async def call_tool(
-        name: str, arguments: dict,
+        name: str,
+        arguments: dict,
     ) -> list[types.ContentBlock]:
         tool_def = get_tool_by_name(name)
         if not tool_def:
@@ -66,37 +169,20 @@ def main(mode: str, port: int) -> int:
             result = _send(mode, name, arguments, port=port)
         except Exception as exc:
             reset_connection()
-            content = [types.TextContent(
-                type="text",
-                text=f"Error ({name}): {exc}\n\n"
-                     "Make sure Fusion 360 is running and the "
-                     "Fusion360MCP add-in is started.",
-            )]
+            content = [
+                types.TextContent(
+                    type="text",
+                    text=f"Error ({name}): {exc}\n\n"
+                    "Make sure Fusion 360 is running and the "
+                    "Fusion360MCP add-in is started.",
+                )
+            ]
             return types.CallToolResult(
-                content=content, isError=True,
+                content=content,
+                isError=True,
             )
 
-        # Detect errors from the add-in
-        is_error = False
-        if isinstance(result, dict):
-            status = result.get("status", "")
-            if status == "error" or "error" in result:
-                is_error = True
-
-        # Format response
-        lines = [f"**{name}** {'ERROR' if is_error else 'OK'}"]
-        if isinstance(result, dict):
-            for k, v in result.items():
-                lines.append(f"  {k}: {v}")
-        else:
-            lines.append(f"  {result}")
-
-        content = [types.TextContent(type="text", text="\n".join(lines))]
-        if is_error:
-            return types.CallToolResult(
-                content=content, isError=True,
-            )
-        return content
+        return _format_result(name, result)
 
     # ── resources ────────────────────────────────────────────────────
 
@@ -129,12 +215,14 @@ def main(mode: str, port: int) -> int:
             try:
                 result = _send(mode, "ping", port=port)
                 return json.dumps(
-                    {"connected": True, "ping": result}, indent=2,
+                    {"connected": True, "ping": result},
+                    indent=2,
                 )
             except Exception as exc:
                 reset_connection()
                 return json.dumps(
-                    {"connected": False, "error": str(exc)}, indent=2,
+                    {"connected": False, "error": str(exc)},
+                    indent=2,
                 )
 
         if uri == "fusion360://design":
@@ -148,7 +236,9 @@ def main(mode: str, port: int) -> int:
         if uri == "fusion360://parameters":
             try:
                 result = _send(
-                    mode, "get_parameters", port=port,
+                    mode,
+                    "get_parameters",
+                    port=port,
                 )
                 return json.dumps(result, indent=2)
             except Exception as exc:
@@ -161,8 +251,10 @@ def main(mode: str, port: int) -> int:
             name = body_match.group(1)
             try:
                 result = _send(
-                    mode, "get_object_info",
-                    {"name": name}, port=port,
+                    mode,
+                    "get_object_info",
+                    {"name": name},
+                    port=port,
                 )
                 return json.dumps(result, indent=2)
             except Exception as exc:
@@ -170,14 +262,17 @@ def main(mode: str, port: int) -> int:
                 return json.dumps({"error": str(exc)}, indent=2)
 
         comp_match = re.match(
-            r"^fusion360://component/(.+)$", uri,
+            r"^fusion360://component/(.+)$",
+            uri,
         )
         if comp_match:
             name = comp_match.group(1)
             try:
                 result = _send(
-                    mode, "get_object_info",
-                    {"name": name}, port=port,
+                    mode,
+                    "get_object_info",
+                    {"name": name},
+                    port=port,
                 )
                 return json.dumps(result, indent=2)
             except Exception as exc:
@@ -210,9 +305,7 @@ def main(mode: str, port: int) -> int:
     _PROMPTS = {
         "create-box": types.Prompt(
             name="create-box",
-            description=(
-                "Guide for creating a parametric box in Fusion 360"
-            ),
+            description=("Guide for creating a parametric box in Fusion 360"),
             arguments=[
                 types.PromptArgument(
                     name="length",
@@ -234,24 +327,19 @@ def main(mode: str, port: int) -> int:
         "model-threaded-bolt": types.Prompt(
             name="model-threaded-bolt",
             description=(
-                "Step-by-step guide for modeling a "
-                "threaded bolt in Fusion 360"
+                "Step-by-step guide for modeling a threaded bolt in Fusion 360"
             ),
             arguments=[
                 types.PromptArgument(
                     name="designation",
-                    description=(
-                        "Thread designation (e.g. M10x1.5)"
-                    ),
+                    description=("Thread designation (e.g. M10x1.5)"),
                     required=False,
                 ),
             ],
         ),
         "sheet-metal-enclosure": types.Prompt(
             name="sheet-metal-enclosure",
-            description=(
-                "Guide for creating a sheet metal enclosure"
-            ),
+            description=("Guide for creating a sheet metal enclosure"),
             arguments=[
                 types.PromptArgument(
                     name="length",
@@ -278,7 +366,8 @@ def main(mode: str, port: int) -> int:
 
     @app.get_prompt()
     async def get_prompt(
-        name: str, arguments: dict | None = None,
+        name: str,
+        arguments: dict | None = None,
     ) -> types.GetPromptResult:
         prompt = _PROMPTS.get(name)
         if not prompt:
@@ -329,7 +418,8 @@ def main(mode: str, port: int) -> int:
                 types.PromptMessage(
                     role="user",
                     content=types.TextContent(
-                        type="text", text=text,
+                        type="text",
+                        text=text,
                     ),
                 ),
             ],
@@ -341,8 +431,7 @@ def main(mode: str, port: int) -> int:
 
     async def arun():
         async with stdio_server() as streams:
-            await app.run(streams[0], streams[1],
-                          app.create_initialization_options())
+            await app.run(streams[0], streams[1], app.create_initialization_options())
 
     anyio.run(arun)
     return 0

--- a/src/fusion360_mcp/tools.py
+++ b/src/fusion360_mcp/tools.py
@@ -2041,6 +2041,39 @@ TOOLS: list[dict] = [
             "properties": {},
         },
     },
+    # ── design type safety ──────────────────────────────────────────────
+    {
+        "name": "get_design_type",
+        "title": "Get Design Type",
+        "description": (
+            "Check if the design is in parametric or direct mode. "
+            "Use this to detect accidental mode switches."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+    {
+        "name": "set_design_type",
+        "title": "Set Design Type",
+        "description": (
+            "Switch design type between 'parametric' and 'direct'. "
+            "Use 'parametric' to recover from accidental direct-mode "
+            "switches (equivalent to Capture Design History in the UI)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "required": ["design_type"],
+            "properties": {
+                "design_type": {
+                    "type": "string",
+                    "enum": ["parametric", "direct"],
+                    "description": "Target design type",
+                },
+            },
+        },
+    },
 ]
 
 # ── tool annotations ──────────────────────────────────────────────────
@@ -2054,6 +2087,7 @@ _READ_ONLY = {
     "check_interference", "ping",
     "cam_list_setups", "cam_list_operations",
     "cam_get_operation_info",
+    "get_design_type",
 }
 _DESTRUCTIVE = {"delete_all", "delete_parameter"}
 _IDEMPOTENT = {
@@ -2064,6 +2098,7 @@ _IDEMPOTENT = {
     "set_parameter", "set_appearance",
     "cam_list_setups", "cam_list_operations",
     "cam_get_operation_info",
+    "get_design_type", "set_design_type",
 }
 
 for _t in TOOLS:

--- a/src/fusion360_mcp/tools.py
+++ b/src/fusion360_mcp/tools.py
@@ -58,8 +58,8 @@ TOOLS: list[dict] = [
             "type": "object",
             "required": ["width", "height"],
             "properties": {
-                "width":    {"type": "number", "minimum": 0.001},
-                "height":   {"type": "number", "minimum": 0.001},
+                "width": {"type": "number", "minimum": 0.001},
+                "height": {"type": "number", "minimum": 0.001},
                 "origin_x": {"type": "number", "default": 0},
                 "origin_y": {"type": "number", "default": 0},
                 "origin_z": {"type": "number", "default": 0},
@@ -74,7 +74,7 @@ TOOLS: list[dict] = [
             "type": "object",
             "required": ["radius"],
             "properties": {
-                "radius":   {"type": "number", "minimum": 0.001},
+                "radius": {"type": "number", "minimum": 0.001},
                 "center_x": {"type": "number", "default": 0},
                 "center_y": {"type": "number", "default": 0},
                 "center_z": {"type": "number", "default": 0},
@@ -92,9 +92,9 @@ TOOLS: list[dict] = [
                 "start_x": {"type": "number"},
                 "start_y": {"type": "number"},
                 "start_z": {"type": "number", "default": 0},
-                "end_x":   {"type": "number"},
-                "end_y":   {"type": "number"},
-                "end_z":   {"type": "number", "default": 0},
+                "end_x": {"type": "number"},
+                "end_y": {"type": "number"},
+                "end_z": {"type": "number", "default": 0},
             },
         },
     },
@@ -107,7 +107,7 @@ TOOLS: list[dict] = [
             "type": "object",
             "required": ["height"],
             "properties": {
-                "height":        {"type": "number"},
+                "height": {"type": "number"},
                 "profile_index": {"type": "integer", "default": 0, "minimum": 0},
                 "operation": {
                     "type": "string",
@@ -130,11 +130,11 @@ TOOLS: list[dict] = [
             "type": "object",
             "required": ["angle"],
             "properties": {
-                "angle":            {"type": "number", "minimum": 0.1, "maximum": 360},
-                "profile_index":    {"type": "integer", "default": 0},
-                "axis_origin_x":    {"type": "number", "default": 0},
-                "axis_origin_y":    {"type": "number", "default": 0},
-                "axis_origin_z":    {"type": "number", "default": 0},
+                "angle": {"type": "number", "minimum": 0.1, "maximum": 360},
+                "profile_index": {"type": "integer", "default": 0},
+                "axis_origin_x": {"type": "number", "default": 0},
+                "axis_origin_y": {"type": "number", "default": 0},
+                "axis_origin_z": {"type": "number", "default": 0},
                 "axis_direction_x": {"type": "number", "default": 1},
                 "axis_direction_y": {"type": "number", "default": 0},
                 "axis_direction_z": {"type": "number", "default": 0},
@@ -154,7 +154,7 @@ TOOLS: list[dict] = [
             "type": "object",
             "required": ["radius"],
             "properties": {
-                "radius":    {"type": "number", "minimum": 0.001},
+                "radius": {"type": "number", "minimum": 0.001},
                 "body_name": {"type": "string", "description": "Body name (preferred)"},
                 "body_index": {"type": "integer", "default": 0},
                 "edge_selection": {
@@ -173,7 +173,7 @@ TOOLS: list[dict] = [
             "type": "object",
             "required": ["distance"],
             "properties": {
-                "distance":  {"type": "number", "minimum": 0.001},
+                "distance": {"type": "number", "minimum": 0.001},
                 "body_name": {"type": "string"},
                 "body_index": {"type": "integer", "default": 0},
                 "edge_selection": {
@@ -192,8 +192,8 @@ TOOLS: list[dict] = [
             "type": "object",
             "required": ["thickness"],
             "properties": {
-                "thickness":  {"type": "number", "minimum": 0.001},
-                "body_name":  {"type": "string"},
+                "thickness": {"type": "number", "minimum": 0.001},
+                "body_name": {"type": "string"},
                 "body_index": {"type": "integer", "default": 0},
                 "face_selection": {
                     "type": "string",
@@ -215,7 +215,7 @@ TOOLS: list[dict] = [
                     "type": "string",
                     "enum": ["xy", "yz", "xz"],
                 },
-                "body_name":  {"type": "string"},
+                "body_name": {"type": "string"},
                 "body_index": {"type": "integer", "default": 0},
             },
         },
@@ -261,7 +261,7 @@ TOOLS: list[dict] = [
             "required": ["target_body", "tool_body"],
             "properties": {
                 "target_body": {"type": "string"},
-                "tool_body":   {"type": "string"},
+                "tool_body": {"type": "string"},
                 "operation": {
                     "type": "string",
                     "enum": ["join", "cut", "intersect"],
@@ -362,8 +362,11 @@ TOOLS: list[dict] = [
             "required": ["sides", "radius"],
             "properties": {
                 "sides": {"type": "integer", "minimum": 3, "maximum": 64},
-                "radius": {"type": "number", "minimum": 0.001,
-                           "description": "Circumradius (cm)"},
+                "radius": {
+                    "type": "number",
+                    "minimum": 0.001,
+                    "description": "Circumradius (cm)",
+                },
                 "center_x": {"type": "number", "default": 0},
                 "center_y": {"type": "number", "default": 0},
                 "center_z": {"type": "number", "default": 0},
@@ -374,8 +377,7 @@ TOOLS: list[dict] = [
         "name": "draw_arc",
         "title": "Draw Arc",
         "description": (
-            "Draw an arc in the most recent sketch "
-            "(center + start point + sweep angle)"
+            "Draw an arc in the most recent sketch (center + start point + sweep angle)"
         ),
         "inputSchema": {
             "type": "object",
@@ -428,11 +430,17 @@ TOOLS: list[dict] = [
             "properties": {
                 "body_name": {"type": "string"},
                 "x_count": {"type": "integer", "minimum": 1, "default": 1},
-                "x_spacing": {"type": "number", "default": 1.0,
-                              "description": "Spacing between columns (cm)"},
+                "x_spacing": {
+                    "type": "number",
+                    "default": 1.0,
+                    "description": "Spacing between columns (cm)",
+                },
                 "y_count": {"type": "integer", "minimum": 1, "default": 1},
-                "y_spacing": {"type": "number", "default": 1.0,
-                              "description": "Spacing between rows (cm)"},
+                "y_spacing": {
+                    "type": "number",
+                    "default": 1.0,
+                    "description": "Spacing between rows (cm)",
+                },
             },
         },
     },
@@ -490,8 +498,15 @@ TOOLS: list[dict] = [
                 "component_two": {"type": "string"},
                 "joint_type": {
                     "type": "string",
-                    "enum": ["rigid", "revolute", "slider", "cylindrical",
-                             "pin_slot", "planar", "ball"],
+                    "enum": [
+                        "rigid",
+                        "revolute",
+                        "slider",
+                        "cylindrical",
+                        "pin_slot",
+                        "planar",
+                        "ball",
+                    ],
                     "default": "rigid",
                 },
             },
@@ -533,8 +548,7 @@ TOOLS: list[dict] = [
                 "file_path": {
                     "type": "string",
                     "description": (
-                        "Destination path "
-                        "(default: ~/Desktop/<design_name>.f3d)"
+                        "Destination path (default: ~/Desktop/<design_name>.f3d)"
                     ),
                 },
             },
@@ -608,10 +622,19 @@ TOOLS: list[dict] = [
                 "constraint_type": {
                     "type": "string",
                     "enum": [
-                        "coincident", "parallel", "perpendicular",
-                        "tangent", "equal", "fix", "midpoint",
-                        "concentric", "horizontal", "vertical",
-                        "symmetry", "collinear", "smooth",
+                        "coincident",
+                        "parallel",
+                        "perpendicular",
+                        "tangent",
+                        "equal",
+                        "fix",
+                        "midpoint",
+                        "concentric",
+                        "horizontal",
+                        "vertical",
+                        "symmetry",
+                        "collinear",
+                        "smooth",
                     ],
                 },
                 "entity_one": {
@@ -630,8 +653,7 @@ TOOLS: list[dict] = [
                 "symmetry_line": {
                     "type": "integer",
                     "description": (
-                        "Index of the symmetry line "
-                        "(only for symmetry constraint)"
+                        "Index of the symmetry line (only for symmetry constraint)"
                     ),
                     "minimum": 0,
                 },
@@ -657,8 +679,12 @@ TOOLS: list[dict] = [
                 "dimension_type": {
                     "type": "string",
                     "enum": [
-                        "distance", "horizontal", "vertical",
-                        "angular", "radial", "diameter",
+                        "distance",
+                        "horizontal",
+                        "vertical",
+                        "angular",
+                        "radial",
+                        "diameter",
                     ],
                 },
                 "value": {
@@ -697,16 +723,17 @@ TOOLS: list[dict] = [
                 "method": {
                     "type": "string",
                     "enum": [
-                        "offset", "angle", "midplane",
-                        "three_points", "tangent",
+                        "offset",
+                        "angle",
+                        "midplane",
+                        "three_points",
+                        "tangent",
                     ],
                 },
                 "plane": {
                     "type": "string",
                     "enum": ["xy", "yz", "xz"],
-                    "description": (
-                        "Reference plane (for offset/angle)"
-                    ),
+                    "description": ("Reference plane (for offset/angle)"),
                 },
                 "offset": {
                     "type": "number",
@@ -718,10 +745,7 @@ TOOLS: list[dict] = [
                 },
                 "edge_name": {
                     "type": "string",
-                    "description": (
-                        "Edge or axis to rotate around "
-                        "(for angle method)"
-                    ),
+                    "description": ("Edge or axis to rotate around (for angle method)"),
                 },
                 "plane_one": {
                     "type": "string",
@@ -768,8 +792,10 @@ TOOLS: list[dict] = [
                 "method": {
                     "type": "string",
                     "enum": [
-                        "two_points", "intersection",
-                        "edge", "perpendicular_at_point",
+                        "two_points",
+                        "intersection",
+                        "edge",
+                        "perpendicular_at_point",
                     ],
                 },
                 "point_one": {
@@ -787,16 +813,12 @@ TOOLS: list[dict] = [
                 "plane_one": {
                     "type": "string",
                     "enum": ["xy", "yz", "xz"],
-                    "description": (
-                        "First plane (for intersection)"
-                    ),
+                    "description": ("First plane (for intersection)"),
                 },
                 "plane_two": {
                     "type": "string",
                     "enum": ["xy", "yz", "xz"],
-                    "description": (
-                        "Second plane (for intersection)"
-                    ),
+                    "description": ("Second plane (for intersection)"),
                 },
                 "body_name": {
                     "type": "string",
@@ -836,18 +858,13 @@ TOOLS: list[dict] = [
                         "maxItems": 3,
                     },
                     "minItems": 2,
-                    "description": (
-                        "Array of [x,y] or [x,y,z] points"
-                    ),
+                    "description": ("Array of [x,y] or [x,y,z] points"),
                 },
                 "degree": {
                     "type": "integer",
                     "enum": [3, 5],
                     "default": 3,
-                    "description": (
-                        "Spline degree "
-                        "(only for control_points, 3 or 5)"
-                    ),
+                    "description": ("Spline degree (only for control_points, 3 or 5)"),
                 },
             },
         },
@@ -867,9 +884,7 @@ TOOLS: list[dict] = [
                 "curve_index": {
                     "type": "integer",
                     "minimum": 0,
-                    "description": (
-                        "Index of a curve in the connected loop"
-                    ),
+                    "description": ("Index of a curve in the connected loop"),
                 },
                 "offset_distance": {
                     "type": "number",
@@ -888,9 +903,7 @@ TOOLS: list[dict] = [
                 },
                 "sketch_name": {
                     "type": "string",
-                    "description": (
-                        "Sketch name (default: most recent)"
-                    ),
+                    "description": ("Sketch name (default: most recent)"),
                 },
             },
         },
@@ -913,15 +926,11 @@ TOOLS: list[dict] = [
                 },
                 "point_x": {
                     "type": "number",
-                    "description": (
-                        "X near the segment to remove"
-                    ),
+                    "description": ("X near the segment to remove"),
                 },
                 "point_y": {
                     "type": "number",
-                    "description": (
-                        "Y near the segment to remove"
-                    ),
+                    "description": ("Y near the segment to remove"),
                 },
                 "sketch_name": {"type": "string"},
             },
@@ -959,10 +968,7 @@ TOOLS: list[dict] = [
     {
         "name": "create_thread",
         "title": "Create Thread",
-        "description": (
-            "Add threads to a cylindrical face "
-            "(cosmetic or modeled)"
-        ),
+        "description": ("Add threads to a cylindrical face (cosmetic or modeled)"),
         "inputSchema": {
             "type": "object",
             "required": ["body_name", "face_index"],
@@ -971,9 +977,7 @@ TOOLS: list[dict] = [
                 "face_index": {
                     "type": "integer",
                     "minimum": 0,
-                    "description": (
-                        "Index of the cylindrical face"
-                    ),
+                    "description": ("Index of the cylindrical face"),
                 },
                 "is_internal": {
                     "type": "boolean",
@@ -991,9 +995,7 @@ TOOLS: list[dict] = [
                 "thread_designation": {
                     "type": "string",
                     "default": "M10x1.5",
-                    "description": (
-                        "Size designation (e.g. 'M10x1.5')"
-                    ),
+                    "description": ("Size designation (e.g. 'M10x1.5')"),
                 },
                 "thread_class": {
                     "type": "string",
@@ -1003,10 +1005,7 @@ TOOLS: list[dict] = [
                 "is_modeled": {
                     "type": "boolean",
                     "default": False,
-                    "description": (
-                        "True = physical geometry, "
-                        "False = cosmetic"
-                    ),
+                    "description": ("True = physical geometry, False = cosmetic"),
                 },
                 "is_full_length": {
                     "type": "boolean",
@@ -1016,8 +1015,7 @@ TOOLS: list[dict] = [
                 "thread_length": {
                     "type": "number",
                     "description": (
-                        "Thread length in cm "
-                        "(only if is_full_length=false)"
+                        "Thread length in cm (only if is_full_length=false)"
                     ),
                 },
             },
@@ -1056,9 +1054,7 @@ TOOLS: list[dict] = [
                 "is_tangent_chain": {
                     "type": "boolean",
                     "default": True,
-                    "description": (
-                        "Include tangent-connected faces"
-                    ),
+                    "description": ("Include tangent-connected faces"),
                 },
             },
         },
@@ -1076,10 +1072,7 @@ TOOLS: list[dict] = [
                     "type": "string",
                     "enum": ["xy", "yz", "xz"],
                     "default": "xy",
-                    "description": (
-                        "Plane to split with "
-                        "(or use splitting_body)"
-                    ),
+                    "description": ("Plane to split with (or use splitting_body)"),
                 },
                 "splitting_body": {
                     "type": "string",
@@ -1091,9 +1084,7 @@ TOOLS: list[dict] = [
                 "extend_tool": {
                     "type": "boolean",
                     "default": True,
-                    "description": (
-                        "Extend tool to cut through entire body"
-                    ),
+                    "description": ("Extend tool to cut through entire body"),
                 },
             },
         },
@@ -1110,10 +1101,7 @@ TOOLS: list[dict] = [
                 "face_indices": {
                     "type": "array",
                     "items": {"type": "integer", "minimum": 0},
-                    "description": (
-                        "Indices of faces to split "
-                        "(default: all faces)"
-                    ),
+                    "description": ("Indices of faces to split (default: all faces)"),
                 },
                 "splitting_plane": {
                     "type": "string",
@@ -1130,9 +1118,7 @@ TOOLS: list[dict] = [
     {
         "name": "offset_faces",
         "title": "Offset Faces",
-        "description": (
-            "Push/pull faces of a body by a distance"
-        ),
+        "description": ("Push/pull faces of a body by a distance"),
         "inputSchema": {
             "type": "object",
             "required": ["body_name", "distance"],
@@ -1140,10 +1126,7 @@ TOOLS: list[dict] = [
                 "body_name": {"type": "string"},
                 "distance": {
                     "type": "number",
-                    "description": (
-                        "Offset distance in cm "
-                        "(positive = outward)"
-                    ),
+                    "description": ("Offset distance in cm (positive = outward)"),
                 },
                 "face_selection": {
                     "type": "string",
@@ -1154,10 +1137,7 @@ TOOLS: list[dict] = [
                 "face_indices": {
                     "type": "array",
                     "items": {"type": "integer", "minimum": 0},
-                    "description": (
-                        "Specific face indices "
-                        "(overrides face_selection)"
-                    ),
+                    "description": ("Specific face indices (overrides face_selection)"),
                 },
             },
         },
@@ -1179,9 +1159,7 @@ TOOLS: list[dict] = [
                 "scale_x": {
                     "type": "number",
                     "minimum": 0.001,
-                    "description": (
-                        "X scale (overrides uniform scale)"
-                    ),
+                    "description": ("X scale (overrides uniform scale)"),
                 },
                 "scale_y": {
                     "type": "number",
@@ -1216,8 +1194,7 @@ TOOLS: list[dict] = [
         "name": "create_box",
         "title": "Create Box",
         "description": (
-            "Create a box primitive "
-            "(non-parametric via TemporaryBRepManager)"
+            "Create a box primitive (non-parametric via TemporaryBRepManager)"
         ),
         "inputSchema": {
             "type": "object",
@@ -1236,8 +1213,7 @@ TOOLS: list[dict] = [
         "name": "create_cylinder",
         "title": "Create Cylinder",
         "description": (
-            "Create a cylinder primitive "
-            "(non-parametric via TemporaryBRepManager)"
+            "Create a cylinder primitive (non-parametric via TemporaryBRepManager)"
         ),
         "inputSchema": {
             "type": "object",
@@ -1261,8 +1237,7 @@ TOOLS: list[dict] = [
         "name": "create_sphere",
         "title": "Create Sphere",
         "description": (
-            "Create a sphere primitive "
-            "(non-parametric via TemporaryBRepManager)"
+            "Create a sphere primitive (non-parametric via TemporaryBRepManager)"
         ),
         "inputSchema": {
             "type": "object",
@@ -1279,8 +1254,7 @@ TOOLS: list[dict] = [
         "name": "create_torus",
         "title": "Create Torus",
         "description": (
-            "Create a torus primitive "
-            "(non-parametric via TemporaryBRepManager)"
+            "Create a torus primitive (non-parametric via TemporaryBRepManager)"
         ),
         "inputSchema": {
             "type": "object",
@@ -1318,7 +1292,9 @@ TOOLS: list[dict] = [
         "inputSchema": {
             "type": "object",
             "required": [
-                "component_one", "component_two", "joint_type",
+                "component_one",
+                "component_two",
+                "joint_type",
             ],
             "properties": {
                 "component_one": {"type": "string"},
@@ -1326,9 +1302,13 @@ TOOLS: list[dict] = [
                 "joint_type": {
                     "type": "string",
                     "enum": [
-                        "rigid", "revolute", "slider",
-                        "cylindrical", "pin_slot",
-                        "planar", "ball",
+                        "rigid",
+                        "revolute",
+                        "slider",
+                        "cylindrical",
+                        "pin_slot",
+                        "planar",
+                        "ball",
                     ],
                     "default": "rigid",
                 },
@@ -1352,9 +1332,7 @@ TOOLS: list[dict] = [
                 "include_children": {
                     "type": "boolean",
                     "default": True,
-                    "description": (
-                        "Include child sub-components"
-                    ),
+                    "description": ("Include child sub-components"),
                 },
             },
         },
@@ -1363,9 +1341,7 @@ TOOLS: list[dict] = [
     {
         "name": "measure_distance",
         "title": "Measure Distance",
-        "description": (
-            "Measure minimum distance between two entities"
-        ),
+        "description": ("Measure minimum distance between two entities"),
         "inputSchema": {
             "type": "object",
             "required": ["entity_one", "entity_two"],
@@ -1373,8 +1349,7 @@ TOOLS: list[dict] = [
                 "entity_one": {
                     "type": "string",
                     "description": (
-                        "First entity name "
-                        "(body, sketch, or point 'x,y,z')"
+                        "First entity name (body, sketch, or point 'x,y,z')"
                     ),
                 },
                 "entity_two": {
@@ -1407,8 +1382,7 @@ TOOLS: list[dict] = [
         "name": "get_physical_properties",
         "title": "Get Physical Properties",
         "description": (
-            "Get mass, volume, surface area, center of mass, "
-            "and density of a body"
+            "Get mass, volume, surface area, center of mass, and density of a body"
         ),
         "inputSchema": {
             "type": "object",
@@ -1446,9 +1420,7 @@ TOOLS: list[dict] = [
     {
         "name": "check_interference",
         "title": "Check Interference",
-        "description": (
-            "Detect collisions between components/bodies"
-        ),
+        "description": ("Detect collisions between components/bodies"),
         "inputSchema": {
             "type": "object",
             "required": ["component_names"],
@@ -1457,16 +1429,12 @@ TOOLS: list[dict] = [
                     "type": "array",
                     "items": {"type": "string"},
                     "minItems": 2,
-                    "description": (
-                        "Names of components to check"
-                    ),
+                    "description": ("Names of components to check"),
                 },
                 "include_coincident_faces": {
                     "type": "boolean",
                     "default": False,
-                    "description": (
-                        "Count touching faces as interference"
-                    ),
+                    "description": ("Count touching faces as interference"),
                 },
             },
         },
@@ -1503,9 +1471,7 @@ TOOLS: list[dict] = [
                 "face_index": {
                     "type": "integer",
                     "minimum": 0,
-                    "description": (
-                        "Face index (if target_type=face)"
-                    ),
+                    "description": ("Face index (if target_type=face)"),
                 },
             },
         },
@@ -1514,32 +1480,23 @@ TOOLS: list[dict] = [
     {
         "name": "project_geometry",
         "title": "Project Geometry",
-        "description": (
-            "Project edges or bodies onto the active sketch plane"
-        ),
+        "description": ("Project edges or bodies onto the active sketch plane"),
         "inputSchema": {
             "type": "object",
             "required": ["source_name"],
             "properties": {
                 "source_name": {
                     "type": "string",
-                    "description": (
-                        "Name of body or edge to project"
-                    ),
+                    "description": ("Name of body or edge to project"),
                 },
                 "is_linked": {
                     "type": "boolean",
                     "default": True,
-                    "description": (
-                        "True = parametrically linked "
-                        "to source geometry"
-                    ),
+                    "description": ("True = parametrically linked to source geometry"),
                 },
                 "sketch_name": {
                     "type": "string",
-                    "description": (
-                        "Target sketch (default: most recent)"
-                    ),
+                    "description": ("Target sketch (default: most recent)"),
                 },
             },
         },
@@ -1573,9 +1530,7 @@ TOOLS: list[dict] = [
     {
         "name": "patch_surface",
         "title": "Patch Surface",
-        "description": (
-            "Create a patch surface from boundary edges"
-        ),
+        "description": ("Create a patch surface from boundary edges"),
         "inputSchema": {
             "type": "object",
             "required": ["sketch_name"],
@@ -1600,9 +1555,7 @@ TOOLS: list[dict] = [
     {
         "name": "stitch_surfaces",
         "title": "Stitch Surfaces",
-        "description": (
-            "Stitch surface bodies into a single body"
-        ),
+        "description": ("Stitch surface bodies into a single body"),
         "inputSchema": {
             "type": "object",
             "required": ["body_names"],
@@ -1645,9 +1598,7 @@ TOOLS: list[dict] = [
     {
         "name": "ruled_surface",
         "title": "Ruled Surface",
-        "description": (
-            "Create a ruled surface from an edge or sketch curve"
-        ),
+        "description": ("Create a ruled surface from an edge or sketch curve"),
         "inputSchema": {
             "type": "object",
             "required": ["body_name", "edge_index"],
@@ -1693,9 +1644,7 @@ TOOLS: list[dict] = [
     {
         "name": "create_flange",
         "title": "Create Flange",
-        "description": (
-            "Create a sheet metal flange on an edge"
-        ),
+        "description": ("Create a sheet metal flange on an edge"),
         "inputSchema": {
             "type": "object",
             "required": ["body_name", "edge_index"],
@@ -1750,9 +1699,7 @@ TOOLS: list[dict] = [
     {
         "name": "flat_pattern",
         "title": "Flat Pattern",
-        "description": (
-            "Create a flat pattern from a sheet metal body"
-        ),
+        "description": ("Create a flat pattern from a sheet metal body"),
         "inputSchema": {
             "type": "object",
             "required": ["body_name"],
@@ -1773,10 +1720,7 @@ TOOLS: list[dict] = [
                 "bend_indices": {
                     "type": "array",
                     "items": {"type": "integer", "minimum": 0},
-                    "description": (
-                        "Indices of bends to unfold "
-                        "(omit to unfold all)"
-                    ),
+                    "description": ("Indices of bends to unfold (omit to unfold all)"),
                 },
             },
         },
@@ -1852,12 +1796,21 @@ TOOLS: list[dict] = [
                 "strategy": {
                     "type": "string",
                     "enum": [
-                        "face", "2d_contour", "2d_pocket",
-                        "2d_adaptive", "3d_adaptive",
-                        "3d_pocket", "3d_contour",
-                        "3d_scallop", "3d_parallel",
-                        "drilling", "bore", "thread_milling",
-                        "slot", "trace", "engrave",
+                        "face",
+                        "2d_contour",
+                        "2d_pocket",
+                        "2d_adaptive",
+                        "3d_adaptive",
+                        "3d_pocket",
+                        "3d_contour",
+                        "3d_scallop",
+                        "3d_parallel",
+                        "drilling",
+                        "bore",
+                        "thread_milling",
+                        "slot",
+                        "trace",
+                        "engrave",
                     ],
                     "description": "Machining strategy",
                 },
@@ -1874,8 +1827,7 @@ TOOLS: list[dict] = [
                     "type": "number",
                     "minimum": 0.001,
                     "description": (
-                        "Tool diameter (cm) — used if "
-                        "tool_number not specified"
+                        "Tool diameter (cm) — used if tool_number not specified"
                     ),
                 },
                 "stepdown": {
@@ -1886,9 +1838,7 @@ TOOLS: list[dict] = [
                 "stepover": {
                     "type": "number",
                     "minimum": 0.001,
-                    "description": (
-                        "Radial stepover (cm)"
-                    ),
+                    "description": ("Radial stepover (cm)"),
                 },
                 "feed_rate": {
                     "type": "number",
@@ -1901,8 +1851,10 @@ TOOLS: list[dict] = [
                 "coolant": {
                     "type": "string",
                     "enum": [
-                        "disabled", "flood",
-                        "mist", "through_tool",
+                        "disabled",
+                        "flood",
+                        "mist",
+                        "through_tool",
                     ],
                     "default": "flood",
                 },
@@ -1913,24 +1865,18 @@ TOOLS: list[dict] = [
         "name": "cam_generate_toolpath",
         "title": "Generate Toolpath",
         "description": (
-            "Generate toolpaths for a specific operation "
-            "or all operations in a setup"
+            "Generate toolpaths for a specific operation or all operations in a setup"
         ),
         "inputSchema": {
             "type": "object",
             "properties": {
                 "setup_name": {
                     "type": "string",
-                    "description": (
-                        "Setup name (generates all its operations)"
-                    ),
+                    "description": ("Setup name (generates all its operations)"),
                 },
                 "operation_name": {
                     "type": "string",
-                    "description": (
-                        "Specific operation name "
-                        "(overrides setup_name)"
-                    ),
+                    "description": ("Specific operation name (overrides setup_name)"),
                 },
                 "generate_all": {
                     "type": "boolean",
@@ -1943,9 +1889,7 @@ TOOLS: list[dict] = [
     {
         "name": "cam_post_process",
         "title": "Post Process",
-        "description": (
-            "Post-process toolpaths to generate NC code (G-code)"
-        ),
+        "description": ("Post-process toolpaths to generate NC code (G-code)"),
         "inputSchema": {
             "type": "object",
             "required": ["setup_name"],
@@ -1956,10 +1900,7 @@ TOOLS: list[dict] = [
                 },
                 "operation_name": {
                     "type": "string",
-                    "description": (
-                        "Specific operation "
-                        "(omit to post all in setup)"
-                    ),
+                    "description": ("Specific operation (omit to post all in setup)"),
                 },
                 "post_processor": {
                     "type": "string",
@@ -1972,10 +1913,7 @@ TOOLS: list[dict] = [
                 },
                 "output_folder": {
                     "type": "string",
-                    "description": (
-                        "Output directory "
-                        "(default: ~/Desktop)"
-                    ),
+                    "description": ("Output directory (default: ~/Desktop)"),
                 },
                 "output_units": {
                     "type": "string",
@@ -1988,9 +1926,7 @@ TOOLS: list[dict] = [
     {
         "name": "cam_list_setups",
         "title": "List CAM Setups",
-        "description": (
-            "List all manufacturing setups in the document"
-        ),
+        "description": ("List all manufacturing setups in the document"),
         "inputSchema": {
             "type": "object",
             "properties": {},
@@ -1999,9 +1935,7 @@ TOOLS: list[dict] = [
     {
         "name": "cam_list_operations",
         "title": "List CAM Operations",
-        "description": (
-            "List operations within a setup"
-        ),
+        "description": ("List operations within a setup"),
         "inputSchema": {
             "type": "object",
             "required": ["setup_name"],
@@ -2033,8 +1967,7 @@ TOOLS: list[dict] = [
         "name": "ping",
         "title": "Ping",
         "description": (
-            "Health check — returns immediately "
-            "without touching Fusion API"
+            "Health check — returns immediately without touching Fusion API"
         ),
         "inputSchema": {
             "type": "object",
@@ -2074,6 +2007,57 @@ TOOLS: list[dict] = [
             },
         },
     },
+    # ── perception ──────────────────────────────────────────────────────
+    {
+        "name": "render_view",
+        "title": "Render Viewport",
+        "description": (
+            "Capture the active viewport as a PNG so you can visually verify "
+            "the model. Pass a canonical view (iso/front/top/etc.) to "
+            "reposition the camera first, or 'current' to keep it as is. "
+            "Returns base64-encoded image bytes alongside metadata; the MCP "
+            "server delivers it as an image content block."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "view": {
+                    "type": "string",
+                    "enum": [
+                        "current",
+                        "iso",
+                        "front",
+                        "back",
+                        "top",
+                        "bottom",
+                        "left",
+                        "right",
+                    ],
+                    "default": "current",
+                    "description": (
+                        "Camera preset; 'current' preserves the existing view"
+                    ),
+                },
+                "width": {
+                    "type": "integer",
+                    "minimum": 64,
+                    "maximum": 4096,
+                    "default": 1024,
+                },
+                "height": {
+                    "type": "integer",
+                    "minimum": 64,
+                    "maximum": 4096,
+                    "default": 768,
+                },
+                "fit": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Call Viewport.fit() before capture",
+                },
+            },
+        },
+    },
 ]
 
 # ── tool annotations ──────────────────────────────────────────────────
@@ -2081,24 +2065,40 @@ TOOLS: list[dict] = [
 # side-effect profile so MCP clients can auto-approve safe operations.
 
 _READ_ONLY = {
-    "get_scene_info", "get_object_info", "list_components",
-    "get_parameters", "get_physical_properties",
-    "measure_distance", "measure_angle",
-    "check_interference", "ping",
-    "cam_list_setups", "cam_list_operations",
+    "get_scene_info",
+    "get_object_info",
+    "list_components",
+    "get_parameters",
+    "get_physical_properties",
+    "measure_distance",
+    "measure_angle",
+    "check_interference",
+    "ping",
+    "cam_list_setups",
+    "cam_list_operations",
     "cam_get_operation_info",
     "get_design_type",
+    "render_view",
 }
 _DESTRUCTIVE = {"delete_all", "delete_parameter"}
 _IDEMPOTENT = {
-    "ping", "get_scene_info", "get_object_info",
-    "list_components", "get_parameters",
-    "get_physical_properties", "measure_distance",
-    "measure_angle", "check_interference",
-    "set_parameter", "set_appearance",
-    "cam_list_setups", "cam_list_operations",
+    "ping",
+    "get_scene_info",
+    "get_object_info",
+    "list_components",
+    "get_parameters",
+    "get_physical_properties",
+    "measure_distance",
+    "measure_angle",
+    "check_interference",
+    "set_parameter",
+    "set_appearance",
+    "cam_list_setups",
+    "cam_list_operations",
     "cam_get_operation_info",
-    "get_design_type", "set_design_type",
+    "get_design_type",
+    "set_design_type",
+    "render_view",
 }
 
 for _t in TOOLS:

--- a/tests/test_addon_sync.py
+++ b/tests/test_addon_sync.py
@@ -1,0 +1,88 @@
+"""Drift guards: assert addon-side and package-side mirrors stay in sync.
+
+The Fusion add-in is installed into Fusion's AddIns folder and cannot
+import from this package, so a few tables are duplicated:
+
+* ``addon/server/hints.py:_RULES``   ↔  ``src/fusion360_mcp/hints.py:_RULES``
+* ``CommandHandler._MUTATION_COMMANDS``  ↔  ``mock.py:_MUTATION_MOCKS``
+
+If they drift, agents see different error envelopes / delta payloads
+depending on whether they're running against Fusion or mock mode.  These
+tests fail loudly the moment a maintainer updates one side without the
+other.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_module_by_path(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"cannot load {path}"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _extract_class_attr_set(path: Path, class_name: str, attr: str) -> set[str]:
+    """Pull ``ClassName.attr`` (a set/frozenset literal) out of *path* via AST.
+
+    Avoids importing the addon module, which depends on Fusion's ``adsk``
+    runtime and isn't installable in unit-test environments.
+    """
+    tree = ast.parse(path.read_text())
+    for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
+        if cls.name != class_name:
+            continue
+        for stmt in cls.body:
+            if not isinstance(stmt, ast.Assign):
+                continue
+            if not any(isinstance(t, ast.Name) and t.id == attr for t in stmt.targets):
+                continue
+            value = stmt.value
+            # frozenset({...})  →  unwrap the set literal arg
+            if (
+                isinstance(value, ast.Call)
+                and isinstance(value.func, ast.Name)
+                and value.func.id == "frozenset"
+                and value.args
+            ):
+                return set(ast.literal_eval(value.args[0]))
+            return set(ast.literal_eval(value))
+    raise AssertionError(f"{class_name}.{attr} not found in {path}")
+
+
+def test_hints_rules_in_sync():
+    """addon and src copies of hints._RULES must be identical."""
+    addon_hints = _load_module_by_path(
+        REPO_ROOT / "addon" / "server" / "hints.py", "_addon_hints"
+    )
+    src_hints = _load_module_by_path(
+        REPO_ROOT / "src" / "fusion360_mcp" / "hints.py", "_src_hints"
+    )
+    assert addon_hints._RULES == src_hints._RULES, (
+        "addon/server/hints.py and src/fusion360_mcp/hints.py have drifted. "
+        "Update both files in lockstep."
+    )
+
+
+def test_mutation_sets_in_sync():
+    """Addon mutation set and mock mutation set must be identical."""
+    from fusion360_mcp.mock import _MUTATION_MOCKS
+
+    addon_set = _extract_class_attr_set(
+        REPO_ROOT / "addon" / "server" / "command_handler.py",
+        "CommandHandler",
+        "_MUTATION_COMMANDS",
+    )
+    mock_set = set(_MUTATION_MOCKS)
+    assert addon_set == mock_set, (
+        f"_MUTATION_COMMANDS (addon) and _MUTATION_MOCKS (mock.py) have drifted.\n"
+        f"  only in addon: {sorted(addon_set - mock_set)}\n"
+        f"  only in mock:  {sorted(mock_set - addon_set)}"
+    )

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,186 @@
+"""Tests for agent-feedback additions: hints, deltas, render_view, formatting."""
+
+import base64
+
+import mcp.types as types
+import pytest
+
+from fusion360_mcp.hints import classify
+from fusion360_mcp.mock import _MUTATION_MOCKS, mock_command
+from fusion360_mcp.server import _format_result
+
+
+class TestHintClassification:
+    """The hint table maps exception messages to an error_kind + hints."""
+
+    @pytest.mark.parametrize(
+        "msg,expected_kind",
+        [
+            ("No profiles in sketch", "PROFILE_NOT_CLOSED"),
+            ("No active design", "NO_ACTIVE_DESIGN"),
+            ("Body SomeBody not found", "BODY_NOT_FOUND"),
+            ("Sketch Sketch1 not found", "SKETCH_NOT_FOUND"),
+            ("Sweep self-intersects at T=0.4", "SELF_INTERSECTION"),
+            ("Regeneration failed for feature Extrude7", "REGEN_FAILED"),
+            ("Boolean subtract failed — empty result", "BOOLEAN_NO_OP"),
+            ("Invalid input: angle must be > 0", "INVALID_INPUT"),
+            ("Unknown command: bogus", "UNKNOWN_COMMAND"),
+            ("Operation timeout after 30s", "TIMEOUT"),
+        ],
+    )
+    def test_classify_known_messages(self, msg, expected_kind):
+        kind, hints = classify(msg)
+        assert kind == expected_kind, f"'{msg}' classified as {kind}"
+        assert hints, f"'{expected_kind}' should ship with at least one hint"
+
+    def test_classify_unknown_falls_back(self):
+        kind, hints = classify("totally novel failure mode xyz")
+        assert kind == "UNKNOWN"
+        assert hints == []
+
+    def test_classify_accepts_exception(self):
+        kind, hints = classify(RuntimeError("No profiles in sketch"))
+        assert kind == "PROFILE_NOT_CLOSED"
+        assert len(hints) >= 1
+
+
+class TestMockForcedError:
+    """Sending __mock_error__ in params produces an ok=False envelope."""
+
+    def test_forced_error_shape(self):
+        result = mock_command(
+            "extrude",
+            {
+                "height": 1,
+                "__mock_error__": "No profiles in sketch",
+            },
+        )
+        assert result["ok"] is False
+        assert result["error_kind"] == "PROFILE_NOT_CLOSED"
+        assert "hints" in result and result["hints"]
+        assert result["error_message"] == "No profiles in sketch"
+        assert result["mode"] == "mock"
+
+    def test_forced_error_unknown_kind(self):
+        result = mock_command("extrude", {"__mock_error__": "something weird"})
+        assert result["ok"] is False
+        assert result["error_kind"] == "UNKNOWN"
+        assert result["hints"] == []
+
+
+class TestMockDeltas:
+    """Mutation mocks carry a deltas sub-dict; read-only mocks do not."""
+
+    def test_mutation_has_deltas(self):
+        for cmd in _MUTATION_MOCKS:
+            result = mock_command(cmd, {})
+            assert "deltas" in result, f"{cmd} should expose deltas"
+            deltas = result["deltas"]
+            assert "body_count_delta" in deltas
+            assert "mass_g_delta" in deltas
+            assert "bbox_after" in deltas
+
+    def test_read_only_has_no_deltas(self):
+        for cmd in (
+            "ping",
+            "get_scene_info",
+            "get_parameters",
+            "measure_distance",
+            "check_interference",
+        ):
+            result = mock_command(cmd, {})
+            assert "deltas" not in result, f"{cmd} must not fabricate deltas"
+
+    def test_success_is_ok_true(self):
+        assert mock_command("ping")["ok"] is True
+        assert mock_command("extrude", {"height": 1})["ok"] is True
+
+
+class TestMockRenderView:
+    """render_view returns image_base64 that decodes as PNG bytes."""
+
+    def test_render_view_shape(self):
+        result = mock_command("render_view", {"view": "iso"})
+        assert result["ok"] is True
+        assert result["image_format"] == "png"
+        assert result["view"] == "iso"
+        assert isinstance(result["image_base64"], str)
+        decoded = base64.b64decode(result["image_base64"])
+        assert decoded[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_render_view_is_read_only(self):
+        result = mock_command("render_view", {})
+        assert "deltas" not in result
+
+
+class TestFormatResult:
+    """_format_result converts mock/addon envelopes to MCP content blocks."""
+
+    def test_error_path_sets_isError(self):
+        result = {
+            "ok": False,
+            "error_kind": "PROFILE_NOT_CLOSED",
+            "error_message": "No profiles in sketch",
+            "hints": ["close the loop", "verify coincident constraints"],
+            "traceback": "Traceback (...)",
+        }
+        out = _format_result("extrude", result)
+        assert isinstance(out, types.CallToolResult)
+        assert out.isError is True
+        text = out.content[0].text
+        assert "PROFILE_NOT_CLOSED" in text
+        assert "close the loop" in text
+        assert "No profiles in sketch" in text
+
+    def test_success_path_lists_fields(self):
+        result = {
+            "ok": True,
+            "body_name": "Body1",
+            "height": 3.0,
+            "mode": "mock",
+        }
+        out = _format_result("extrude", result)
+        assert isinstance(out, list)
+        text = out[0].text
+        assert "**extrude** OK" in text
+        assert "body_name: Body1" in text
+        assert "height: 3.0" in text
+        # "ok" is a control field — it should not appear in the rendered body
+        assert "\n  ok:" not in text
+
+    def test_deltas_are_rendered(self):
+        result = {
+            "ok": True,
+            "body_name": "Body1",
+            "deltas": {
+                "body_count_before": 0,
+                "body_count_after": 1,
+                "body_count_delta": 1,
+                "mass_g_before": 0.0,
+                "mass_g_after": 7.85,
+                "mass_g_delta": 7.85,
+                "bbox_before": None,
+                "bbox_after": {"min": [0, 0, 0], "max": [1, 1, 1]},
+            },
+        }
+        out = _format_result("extrude", result)
+        text = out[0].text
+        assert "deltas:" in text
+        assert "body_count: 0 → 1" in text
+        assert "+1" in text
+        assert "7.85" in text
+
+    def test_render_view_returns_image_content(self):
+        result = mock_command("render_view", {})
+        out = _format_result("render_view", result)
+        assert isinstance(out, list)
+        # First block is text metadata, second is the image.
+        kinds = [b.type for b in out]
+        assert kinds == ["text", "image"]
+        assert out[1].mimeType == "image/png"
+        assert out[1].data == result["image_base64"]
+
+    def test_non_dict_result(self):
+        out = _format_result("ping", "pong")
+        assert isinstance(out, list)
+        assert "pong" in out[0].text

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -126,6 +126,7 @@ class TestMockSceneControl:
     def test_undo(self):
         result = mock_command("undo")
         assert result["undone"] is True
+        assert "design_type" in result
 
 
 class TestMockExecuteCode:
@@ -607,6 +608,24 @@ class TestMockCAM:
         assert "strategy" in result
         assert "tool_diameter" in result
         assert "has_toolpath" in result
+
+
+class TestMockDesignTypeSafety:
+    def test_get_design_type(self):
+        result = mock_command("get_design_type")
+        assert result["design_type"] == "parametric"
+        assert result["design_type_id"] == 1
+        assert result["mode"] == "mock"
+
+    def test_set_design_type_parametric(self):
+        result = mock_command("set_design_type", {"design_type": "parametric"})
+        assert result["changed"] is True
+        assert result["design_type"] == "parametric"
+
+    def test_set_design_type_direct(self):
+        result = mock_command("set_design_type", {"design_type": "direct"})
+        assert result["changed"] is True
+        assert result["design_type"] == "direct"
 
 
 class TestMockFallback:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -95,6 +95,7 @@ class TestToolAnnotations:
             "check_interference", "ping",
             "cam_list_setups", "cam_list_operations",
             "cam_get_operation_info",
+            "get_design_type",
         }
         for t in TOOLS:
             ann = t["annotations"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -22,11 +22,13 @@ class TestSendRouting:
     def test_mock_mode_all_tools_succeed(self):
         """Every registered tool should succeed through mock routing."""
         from fusion360_mcp.tools import TOOLS
+
         for tool in TOOLS:
             result = _send("mock", tool["name"], {})
             assert isinstance(result, dict)
             assert result.get("mode") == "mock", (
-                f"Tool {tool['name']} missing mode=mock in mock response")
+                f"Tool {tool['name']} missing mode=mock in mock response"
+            )
 
     def test_socket_mode_calls_connection(self):
         """Socket mode should use the TCP connection, not mock."""
@@ -78,36 +80,45 @@ class TestToolAnnotations:
 
     def test_all_tools_have_annotations(self):
         from fusion360_mcp.tools import TOOLS
+
         for t in TOOLS:
             ann = t.get("annotations")
-            assert ann is not None, (
-                f"Tool {t['name']} missing annotations")
+            assert ann is not None, f"Tool {t['name']} missing annotations"
             assert "readOnlyHint" in ann
             assert "destructiveHint" in ann
             assert "idempotentHint" in ann
 
     def test_read_only_tools(self):
         from fusion360_mcp.tools import TOOLS
+
         read_only_names = {
-            "get_scene_info", "get_object_info", "list_components",
-            "get_parameters", "get_physical_properties",
-            "measure_distance", "measure_angle",
-            "check_interference", "ping",
-            "cam_list_setups", "cam_list_operations",
+            "get_scene_info",
+            "get_object_info",
+            "list_components",
+            "get_parameters",
+            "get_physical_properties",
+            "measure_distance",
+            "measure_angle",
+            "check_interference",
+            "ping",
+            "cam_list_setups",
+            "cam_list_operations",
             "cam_get_operation_info",
             "get_design_type",
+            "render_view",
         }
         for t in TOOLS:
             ann = t["annotations"]
             if t["name"] in read_only_names:
-                assert ann["readOnlyHint"] is True, (
-                    f"{t['name']} should be readOnly")
+                assert ann["readOnlyHint"] is True, f"{t['name']} should be readOnly"
             else:
                 assert ann["readOnlyHint"] is False, (
-                    f"{t['name']} should not be readOnly")
+                    f"{t['name']} should not be readOnly"
+                )
 
     def test_destructive_tools(self):
         from fusion360_mcp.tools import TOOLS
+
         destructive = {"delete_all", "delete_parameter"}
         for t in TOOLS:
             ann = t["annotations"]
@@ -118,10 +129,12 @@ class TestToolAnnotations:
 
     def test_annotations_in_mcp_tool_objects(self):
         from fusion360_mcp.tools import get_tool_list
+
         tools = get_tool_list()
         for tool in tools:
             assert tool.annotations is not None, (
-                f"MCP Tool {tool.name} missing annotations")
+                f"MCP Tool {tool.name} missing annotations"
+            )
 
 
 class TestMCPPrompts:
@@ -133,6 +146,7 @@ class TestMCPPrompts:
         # verify the prompt data is importable and structured.
         # This is a basic smoke test.
         import mcp.types as types
+
         assert hasattr(types, "Prompt")
         assert hasattr(types, "PromptArgument")
         assert hasattr(types, "GetPromptResult")
@@ -172,6 +186,7 @@ class TestResourceTemplates:
 
     def test_resource_template_types(self):
         import mcp.types as types
+
         assert hasattr(types, "ResourceTemplate")
 
     def test_body_template_read(self):
@@ -188,12 +203,14 @@ class TestResourceTemplates:
     def test_body_uri_regex_match(self):
         """The body URI regex should extract the name."""
         import re
+
         m = re.match(r"^fusion360://body/(.+)$", "fusion360://body/Box1")
         assert m is not None
         assert m.group(1) == "Box1"
 
     def test_component_uri_regex_match(self):
         import re
+
         m = re.match(
             r"^fusion360://component/(.+)$",
             "fusion360://component/Arm",
@@ -208,25 +225,19 @@ class TestStructuredErrors:
     def test_error_detection_status_field(self):
         """Results with status='error' should be flagged."""
         result = {"status": "error", "message": "Something failed"}
-        is_error = (
-            result.get("status") == "error" or "error" in result
-        )
+        is_error = result.get("status") == "error" or "error" in result
         assert is_error
 
     def test_error_detection_error_key(self):
         """Results with an 'error' key should be flagged."""
         result = {"error": "Connection lost"}
-        is_error = (
-            result.get("status") == "error" or "error" in result
-        )
+        is_error = result.get("status") == "error" or "error" in result
         assert is_error
 
     def test_success_not_flagged(self):
         """Normal results should not be flagged as errors."""
         result = {"status": "ok", "body_name": "Box"}
-        is_error = (
-            result.get("status") == "error" or "error" in result
-        )
+        is_error = result.get("status") == "error" or "error" in result
         assert not is_error
 
 
@@ -270,12 +281,19 @@ class TestResourceTemplateReads:
 
     def test_static_uri_does_not_match_templates(self):
         """Static URIs should not match template patterns."""
-        for static in ["fusion360://status", "fusion360://design",
-                        "fusion360://parameters"]:
+        for static in [
+            "fusion360://status",
+            "fusion360://design",
+            "fusion360://parameters",
+        ]:
             assert re.match(r"^fusion360://body/(.+)$", static) is None
-            assert re.match(
-                r"^fusion360://component/(.+)$", static,
-            ) is None
+            assert (
+                re.match(
+                    r"^fusion360://component/(.+)$",
+                    static,
+                )
+                is None
+            )
 
     def test_unknown_uri_does_not_match(self):
         uri = "fusion360://unknown/thing"
@@ -355,24 +373,18 @@ class TestErrorDetectionEdgeCases:
     def test_result_with_error_key_but_false_value(self):
         """A result with error=None should still flag."""
         result = {"error": None, "body_name": "Box"}
-        is_error = (
-            result.get("status") == "error" or "error" in result
-        )
+        is_error = result.get("status") == "error" or "error" in result
         # "error" key exists, even if value is falsy
         assert is_error
 
     def test_result_with_status_ok_and_no_error(self):
         result = {"status": "ok", "body_name": "Box"}
-        is_error = (
-            result.get("status") == "error" or "error" in result
-        )
+        is_error = result.get("status") == "error" or "error" in result
         assert not is_error
 
     def test_empty_dict_not_flagged(self):
         result = {}
-        is_error = (
-            result.get("status") == "error" or "error" in result
-        )
+        is_error = result.get("status") == "error" or "error" in result
         assert not is_error
 
     def test_non_dict_result(self):
@@ -380,9 +392,7 @@ class TestErrorDetectionEdgeCases:
         result = "some string"
         is_error = False
         if isinstance(result, dict):
-            is_error = (
-                result.get("status") == "error" or "error" in result
-            )
+            is_error = result.get("status") == "error" or "error" in result
         assert not is_error
 
 
@@ -392,6 +402,7 @@ class TestMockDispatchCompleteness:
     def test_every_tool_has_handler(self):
         from fusion360_mcp.mock import _DISPATCH
         from fusion360_mcp.tools import TOOLS
+
         tool_names = {t["name"] for t in TOOLS}
         dispatch_names = set(_DISPATCH.keys())
         missing = tool_names - dispatch_names
@@ -400,6 +411,7 @@ class TestMockDispatchCompleteness:
     def test_no_extra_handlers(self):
         from fusion360_mcp.mock import _DISPATCH
         from fusion360_mcp.tools import TOOLS
+
         tool_names = {t["name"] for t in TOOLS}
         dispatch_names = set(_DISPATCH.keys())
         extra = dispatch_names - tool_names
@@ -408,6 +420,7 @@ class TestMockDispatchCompleteness:
     def test_dispatch_count_matches_tool_count(self):
         from fusion360_mcp.mock import _DISPATCH
         from fusion360_mcp.tools import TOOLS
+
         assert len(_DISPATCH) == len(TOOLS)
 
 
@@ -416,31 +429,29 @@ class TestAnnotationConsistency:
 
     def test_all_read_only_tools_exist(self):
         from fusion360_mcp.tools import _READ_ONLY, TOOLS
+
         tool_names = {t["name"] for t in TOOLS}
         missing = _READ_ONLY - tool_names
-        assert not missing, (
-            f"Read-only set references nonexistent tools: {missing}"
-        )
+        assert not missing, f"Read-only set references nonexistent tools: {missing}"
 
     def test_all_destructive_tools_exist(self):
         from fusion360_mcp.tools import _DESTRUCTIVE, TOOLS
+
         tool_names = {t["name"] for t in TOOLS}
         missing = _DESTRUCTIVE - tool_names
-        assert not missing, (
-            f"Destructive set references nonexistent tools: {missing}"
-        )
+        assert not missing, f"Destructive set references nonexistent tools: {missing}"
 
     def test_all_idempotent_tools_exist(self):
         from fusion360_mcp.tools import _IDEMPOTENT, TOOLS
+
         tool_names = {t["name"] for t in TOOLS}
         missing = _IDEMPOTENT - tool_names
-        assert not missing, (
-            f"Idempotent set references nonexistent tools: {missing}"
-        )
+        assert not missing, f"Idempotent set references nonexistent tools: {missing}"
 
     def test_read_only_implies_idempotent(self):
         """Every read-only tool should also be idempotent."""
         from fusion360_mcp.tools import _IDEMPOTENT, _READ_ONLY
+
         not_idempotent = _READ_ONLY - _IDEMPOTENT
         assert not not_idempotent, (
             f"Read-only tools not marked idempotent: {not_idempotent}"
@@ -449,7 +460,6 @@ class TestAnnotationConsistency:
     def test_destructive_not_read_only(self):
         """No tool should be both destructive and read-only."""
         from fusion360_mcp.tools import _DESTRUCTIVE, _READ_ONLY
+
         overlap = _DESTRUCTIVE & _READ_ONLY
-        assert not overlap, (
-            f"Tools marked both destructive and read-only: {overlap}"
-        )
+        assert not overlap, f"Tools marked both destructive and read-only: {overlap}"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -114,6 +114,8 @@ def test_expected_tools_present():
         "cam_generate_toolpath", "cam_post_process",
         "cam_list_setups", "cam_list_operations",
         "cam_get_operation_info",
+        # design type safety
+        "get_design_type", "set_design_type",
     }
     missing = expected - names
     assert not missing, f"Missing tools: {missing}"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -15,7 +15,8 @@ def test_all_schemas_are_objects():
     for t in TOOLS:
         schema = t["inputSchema"]
         assert schema.get("type") == "object", (
-            f"Tool {t['name']} schema type is not 'object'")
+            f"Tool {t['name']} schema type is not 'object'"
+        )
 
 
 def test_required_fields_exist_in_properties():
@@ -27,13 +28,15 @@ def test_required_fields_exist_in_properties():
         for field in required:
             assert field in props, (
                 f"Tool {t['name']}: required field '{field}' "
-                f"not in properties {list(props)}")
+                f"not in properties {list(props)}"
+            )
 
 
 def test_no_duplicate_tool_names():
     names = [t["name"] for t in TOOLS]
     assert len(names) == len(set(names)), (
-        f"Duplicate tool names: {[n for n in names if names.count(n) > 1]}")
+        f"Duplicate tool names: {[n for n in names if names.count(n) > 1]}"
+    )
 
 
 def test_get_tool_list_returns_mcp_types():
@@ -58,64 +61,115 @@ def test_expected_tools_present():
     names = {t["name"] for t in TOOLS}
     expected = {
         # scene / query
-        "get_scene_info", "get_object_info",
+        "get_scene_info",
+        "get_object_info",
         # sketch
-        "create_sketch", "draw_rectangle", "draw_circle", "draw_line",
+        "create_sketch",
+        "draw_rectangle",
+        "draw_circle",
+        "draw_line",
         # features
-        "extrude", "revolve", "fillet", "chamfer", "shell", "mirror",
+        "extrude",
+        "revolve",
+        "fillet",
+        "chamfer",
+        "shell",
+        "mirror",
         # body ops
-        "move_body", "export_stl", "boolean_operation",
+        "move_body",
+        "export_stl",
+        "boolean_operation",
         # scene control
-        "delete_all", "undo",
+        "delete_all",
+        "undo",
         # code execution
         "execute_code",
         # health
         "ping",
         # new geometry
-        "sweep", "loft", "create_polygon", "draw_arc",
-        "create_hole", "rectangular_pattern", "circular_pattern",
+        "sweep",
+        "loft",
+        "create_polygon",
+        "draw_arc",
+        "create_hole",
+        "rectangular_pattern",
+        "circular_pattern",
         # assembly
-        "create_component", "add_joint", "list_components",
+        "create_component",
+        "add_joint",
+        "list_components",
         # export
-        "export_step", "export_f3d",
+        "export_step",
+        "export_f3d",
         # parameters
-        "get_parameters", "create_parameter", "set_parameter", "delete_parameter",
+        "get_parameters",
+        "create_parameter",
+        "set_parameter",
+        "delete_parameter",
         # sketch constraints & dimensions
-        "add_constraint", "add_dimension",
+        "add_constraint",
+        "add_dimension",
         # construction geometry
-        "create_construction_plane", "create_construction_axis",
+        "create_construction_plane",
+        "create_construction_axis",
         # splines
         "draw_spline",
         # sketch curve operations
-        "offset_curve", "trim_curve", "extend_curve",
+        "offset_curve",
+        "trim_curve",
+        "extend_curve",
         # advanced features
-        "create_thread", "draft_faces", "split_body", "split_face",
-        "offset_faces", "scale_body",
+        "create_thread",
+        "draft_faces",
+        "split_body",
+        "split_face",
+        "offset_faces",
+        "scale_body",
         # direct primitives
-        "create_box", "create_cylinder", "create_sphere", "create_torus",
+        "create_box",
+        "create_cylinder",
+        "create_sphere",
+        "create_torus",
         # assembly (extended)
-        "create_as_built_joint", "create_rigid_group",
+        "create_as_built_joint",
+        "create_rigid_group",
         # inspection / analysis
-        "measure_distance", "measure_angle", "get_physical_properties",
-        "create_section_analysis", "check_interference",
+        "measure_distance",
+        "measure_angle",
+        "get_physical_properties",
+        "create_section_analysis",
+        "check_interference",
         # appearance
         "set_appearance",
         # project geometry
         "project_geometry",
         # timeline control
-        "suppress_feature", "unsuppress_feature",
+        "suppress_feature",
+        "unsuppress_feature",
         # surface operations
-        "patch_surface", "stitch_surfaces", "thicken_surface",
-        "ruled_surface", "trim_surface",
+        "patch_surface",
+        "stitch_surfaces",
+        "thicken_surface",
+        "ruled_surface",
+        "trim_surface",
         # sheet metal
-        "create_flange", "create_bend", "flat_pattern", "unfold",
+        "create_flange",
+        "create_bend",
+        "flat_pattern",
+        "unfold",
         # CAM / manufacturing
-        "cam_create_setup", "cam_create_operation",
-        "cam_generate_toolpath", "cam_post_process",
-        "cam_list_setups", "cam_list_operations",
+        "cam_create_setup",
+        "cam_create_operation",
+        "cam_generate_toolpath",
+        "cam_post_process",
+        "cam_list_setups",
+        "cam_list_operations",
         "cam_get_operation_info",
         # design type safety
-        "get_design_type", "set_design_type",
+        "get_design_type",
+        "set_design_type",
+        # perception
+        "render_view",
     }
     missing = expected - names
     assert not missing, f"Missing tools: {missing}"
@@ -129,12 +183,8 @@ def test_all_tools_have_annotations():
         ann = t.get("annotations")
         assert ann is not None, f"Tool {t['name']} missing annotations"
         for key in ("readOnlyHint", "destructiveHint", "idempotentHint"):
-            assert key in ann, (
-                f"Tool {t['name']} missing annotation '{key}'"
-            )
-            assert isinstance(ann[key], bool), (
-                f"Tool {t['name']}.{key} should be bool"
-            )
+            assert key in ann, f"Tool {t['name']} missing annotation '{key}'"
+            assert isinstance(ann[key], bool), f"Tool {t['name']}.{key} should be bool"
 
 
 def test_property_types_are_valid():
@@ -145,8 +195,7 @@ def test_property_types_are_valid():
         for field, spec in props.items():
             if "type" in spec:
                 assert spec["type"] in valid_types, (
-                    f"Tool {t['name']}.{field}: "
-                    f"invalid type '{spec['type']}'"
+                    f"Tool {t['name']}.{field}: invalid type '{spec['type']}'"
                 )
 
 
@@ -159,9 +208,7 @@ def test_enum_fields_are_lists():
                 assert isinstance(spec["enum"], list), (
                     f"Tool {t['name']}.{field}: enum not a list"
                 )
-                assert len(spec["enum"]) > 0, (
-                    f"Tool {t['name']}.{field}: enum is empty"
-                )
+                assert len(spec["enum"]) > 0, f"Tool {t['name']}.{field}: enum is empty"
 
 
 def test_minimum_less_than_maximum():
@@ -182,14 +229,13 @@ def test_descriptions_are_nonempty():
         assert len(t["description"].strip()) > 0, (
             f"Tool {t['name']} has empty description"
         )
-        assert len(t["title"].strip()) > 0, (
-            f"Tool {t['name']} has empty title"
-        )
+        assert len(t["title"].strip()) > 0, f"Tool {t['name']} has empty title"
 
 
 def test_tool_names_are_snake_case():
     """Tool names should be snake_case."""
     import re
+
     for t in TOOLS:
         assert re.match(r"^[a-z][a-z0-9_]*$", t["name"]), (
             f"Tool name '{t['name']}' is not snake_case"
@@ -200,18 +246,14 @@ def test_get_tool_list_annotations_propagated():
     """MCP Tool objects should carry annotations."""
     tools = get_tool_list()
     for tool in tools:
-        assert tool.annotations is not None, (
-            f"MCP Tool {tool.name} missing annotations"
-        )
+        assert tool.annotations is not None, f"MCP Tool {tool.name} missing annotations"
 
 
 def test_get_tool_by_name_returns_correct_tool():
     """get_tool_by_name should return the exact matching tool."""
     for t in TOOLS:
         found = get_tool_by_name(t["name"])
-        assert found is t, (
-            f"get_tool_by_name('{t['name']}') returned wrong object"
-        )
+        assert found is t, f"get_tool_by_name('{t['name']}') returned wrong object"
 
 
 def test_get_tool_by_name_edge_cases():


### PR DESCRIPTION
## Summary

Gives the agent enough signal after each tool call to course-correct without round-tripping through a render. Inspired by the feedback patterns in [jarvis-onshape-mcp](https://github.com/ReshefElisha/jarvis-onshape-mcp).

- **Structured errors** — addon classifies exceptions via a 12-rule hint table (`hints.py`, mirrored in `src/` for mock + tests). Failures return `{ok: false, error_kind, error_message, hints, traceback}` instead of a raw traceback string. The MCP server surfaces hints and sets `isError=True`. Error kinds: `PROFILE_NOT_CLOSED`, `SKETCH_NOT_FOUND`, `BODY_NOT_FOUND`, `SELF_INTERSECTION`, `REGEN_FAILED`, `BOOLEAN_NO_OP`, `INVALID_INPUT`, `NO_ACTIVE_DESIGN`, `DESIGN_TYPE_MISMATCH`, `TIMEOUT`, `UNKNOWN_COMMAND`, `UNKNOWN`.
- **Per-mutation deltas** — ~30 geometry-mutating commands capture a body_count/bbox/mass snapshot before and after the call and return the diff under `result.deltas`. Read-only commands are unchanged.
- **`render_view` tool** — `Viewport.saveAsImageFile` plus named-view presets (`iso`/`front`/`top`/etc.), returned as base64 PNG. The server emits an MCP `ImageContent` block so vision models can validate geometry. Camera state is saved and restored when a non-`current` view is requested.

## Response shape (new)

**Success (mutation):**
```json
{
  "ok": true,
  "body_name": "Body1",
  "deltas": {
    "body_count_delta": 1,
    "mass_g_before": 0.0, "mass_g_after": 7.85, "mass_g_delta": 7.85,
    "bbox_after": {"min": [0,0,0], "max": [1,1,1]}
  }
}
```

**Failure:**
```json
{
  "ok": false,
  "error_kind": "PROFILE_NOT_CLOSED",
  "error_message": "No profiles in sketch",
  "hints": ["The sketch has no closed profile to extrude/revolve.", "..."],
  "traceback": "..."
}
```

Tool count: 80 → 81. Test count: 249 → 282 (includes a drift guard between addon and src mirrors). `AGENTS.md` documents the new envelope and rendering discipline.

## Test plan

- [x] `uv run pytest -q` — 282 passed (hint classification, forced-error mocks, delta shape, render_view base64 PNG, `_format_result` image path, addon↔src drift guard)
- [x] `uv run ruff check` — clean
- [x] `python -m py_compile addon/server/command_handler.py` — clean
- [x] Live Fusion run on Faust_Harness doc: `ping` → OK, `render_view view=iso` → 171KB PNG returned and rendered as ImageContent, `extrude` without a sketch → `error_kind: SKETCH_NOT_FOUND` with two contextual hints (verified the new envelope is wired through and the addon is running the worktree code at `command_handler.py:215`)
- [x] Fusion add-in loads after adding `hints.py` module import — confirmed by the live ping/render_view round-trip
