### PR TITLE
Add 4 tools (bbox, import_mesh, parametric box, unified export) + LAN host

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 # Fusion360 MCP Server
 
-> **Beta** — This project is under active development. APIs and tool behavior may change between releases. Use at your own discretion. Feedback and bug reports welcome via [GitHub Issues](https://github.com/faust-machines/fusion360-mcp-server/issues).
+> **Fork note** — This is a fork of [faust-machines/fusion360-mcp-server](https://github.com/faust-machines/fusion360-mcp-server) with four added tools oriented toward parametric box construction against imported reference meshes, plus cross-machine LAN support. Upstream credit for the architecture and 90 base tools goes to faust-machines. See [Fork additions](#fork-additions) below.
+
+> **Beta** — This project is under active development. APIs and tool behavior may change between releases. Use at your own discretion.
 
 MCP server that connects AI coding agents to Autodesk Fusion 360 for CAD automation.
 
 Tested with [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Works with any MCP-compatible client — OpenCode, Codex, Cursor, or anything that speaks the [Model Context Protocol](https://modelcontextprotocol.io).
+
+## Fork additions
+
+Four new tools on top of upstream:
+
+- **`get_bounding_box`** — axis-aligned bounding box (min/max/size/center in cm) for a body or component. For components, unions contained bodies.
+- **`import_mesh`** — import STL/OBJ/3MF files as mesh bodies via `MeshBodies.addByFile()`. Unit-aware (`mm`/`cm`/`m`/`in`/`ft`). Use to bring in reference geometry from SketchUp or scanners.
+- **`create_box_parametric`** — history-based box via sketch rectangle + dimensions + extrude. `length`/`width`/`height` accept numbers (cm) or string expressions referencing User Parameters (e.g. `"boxL"`, `"outer - 2 * wall_t"`).
+- **`export`** — unified dispatcher around `export_stl` / `export_step` / `export_f3d`, with format inference from file extension.
+
+Plus LAN-host support for setups where the MCP server and Fusion run on different machines — see [Cross-machine setup](#cross-machine-setup-lan).
 
 ## How it works
 
@@ -80,6 +93,36 @@ uvx fusion360-mcp-server --mode socket
 }
 ```
 </details>
+
+### Cross-machine setup (LAN)
+
+If the MCP server and Fusion 360 run on different machines (e.g. MCP server on a Mac Mini, Fusion on a Windows PC), override the bind/connect address via environment variables on **both** sides.
+
+**On the Fusion host** (where the add-in runs), bind to all interfaces before starting Fusion:
+
+```powershell
+# Windows
+$env:FUSION_MCP_HOST = "0.0.0.0"
+```
+
+```bash
+# macOS / Linux
+export FUSION_MCP_HOST=0.0.0.0
+```
+
+Then start Fusion and run the `Fusion360MCP` add-in. The log line `Server listening on 0.0.0.0:9876` confirms the bind.
+
+**On the MCP-server host**, point the client at the Fusion host's LAN IP:
+
+```bash
+# Either via CLI flag
+uvx fusion360-mcp-server --mode socket --host 192.168.1.42
+
+# Or via env var (useful in MCP client configs)
+FUSION_MCP_HOST=192.168.1.42 uvx fusion360-mcp-server --mode socket
+```
+
+**Security note:** the TCP socket has no authentication. Only expose it on a trusted LAN — never bind to `0.0.0.0` on a host reachable from the public internet.
 
 ### 3. Verify
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Call the `ping` tool from your client. If it returns `{"pong": true}`, everythin
 2. Stop the add-in in Fusion (Shift+S → Add-Ins → Fusion360MCP → Stop)
 3. Delete the add-in folder from Fusion's AddIns directory
 
-## Available Tools (88)
+## Available Tools (89)
 
 ### Scene & Query
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -1,23 +1,10 @@
 # Fusion360 MCP Server
 
-> **Fork note** — This is a fork of [faust-machines/fusion360-mcp-server](https://github.com/faust-machines/fusion360-mcp-server) with four added tools oriented toward parametric box construction against imported reference meshes, plus cross-machine LAN support. Upstream credit for the architecture and 90 base tools goes to faust-machines. See [Fork additions](#fork-additions) below.
-
-> **Beta** — This project is under active development. APIs and tool behavior may change between releases. Use at your own discretion.
+> **Beta** — This project is under active development. APIs and tool behavior may change between releases. Use at your own discretion. Feedback and bug reports welcome via [GitHub Issues](https://github.com/faust-machines/fusion360-mcp-server/issues).
 
 MCP server that connects AI coding agents to Autodesk Fusion 360 for CAD automation.
 
 Tested with [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Works with any MCP-compatible client — OpenCode, Codex, Cursor, or anything that speaks the [Model Context Protocol](https://modelcontextprotocol.io).
-
-## Fork additions
-
-Four new tools on top of upstream:
-
-- **`get_bounding_box`** — axis-aligned bounding box (min/max/size/center in cm) for a body or component. For components, unions contained bodies.
-- **`import_mesh`** — import STL/OBJ/3MF files as mesh bodies via `MeshBodies.addByFile()`. Unit-aware (`mm`/`cm`/`m`/`in`/`ft`). Use to bring in reference geometry from SketchUp or scanners.
-- **`create_box_parametric`** — history-based box via sketch rectangle + dimensions + extrude. `length`/`width`/`height` accept numbers (cm) or string expressions referencing User Parameters (e.g. `"boxL"`, `"outer - 2 * wall_t"`).
-- **`export`** — unified dispatcher around `export_stl` / `export_step` / `export_f3d`, with format inference from file extension.
-
-Plus LAN-host support for setups where the MCP server and Fusion run on different machines — see [Cross-machine setup](#cross-machine-setup-lan).
 
 ## How it works
 
@@ -134,7 +121,7 @@ Call the `ping` tool from your client. If it returns `{"pong": true}`, everythin
 2. Stop the add-in in Fusion (Shift+S → Add-Ins → Fusion360MCP → Stop)
 3. Delete the add-in folder from Fusion's AddIns directory
 
-## Available Tools (84)
+## Available Tools (88)
 
 ### Scene & Query
 | Tool | Description |
@@ -142,6 +129,7 @@ Call the `ping` tool from your client. If it returns `{"pong": true}`, everythin
 | `ping` | Health check (instant, no Fusion API) |
 | `get_scene_info` | Design name, bodies, sketches, features, camera |
 | `get_object_info` | Detailed info about a named body or sketch |
+| `get_bounding_box` | Axis-aligned bbox (min/max/size/center) for body or component; unions all bodies when called on a component |
 | `list_components` | List all components in the design |
 
 ### Design Type Safety
@@ -202,7 +190,8 @@ Call the `ping` tool from your client. If it returns `{"pong": true}`, everythin
 ### Direct Primitives
 | Tool | Description |
 |------|-------------|
-| `create_box` | Box (via TemporaryBRepManager) |
+| `create_box` | Box (via TemporaryBRepManager, history-less) |
+| `create_box_parametric` | History-based box: sketch rectangle + dimensions + extrude. `length`/`width`/`height` accept numbers (cm) or string expressions referencing User Parameters (e.g. `"boxL"`, `"outer - 2*wall_t"`) |
 | `create_cylinder` | Cylinder |
 | `create_sphere` | Sphere |
 | `create_torus` | Torus |
@@ -260,12 +249,14 @@ Call the `ping` tool from your client. If it returns `{"pong": true}`, everythin
 | `set_parameter` | Update a parameter value |
 | `delete_parameter` | Remove a parameter |
 
-### Export
+### Import / Export
 | Tool | Description |
 |------|-------------|
+| `import_mesh` | Import STL/OBJ/3MF as mesh body via `MeshBodies.addByFile()`. Unit-aware (`mm`/`cm`/`m`/`in`/`ft`). Returns the mesh name and bounding box |
 | `export_stl` | Export body as STL (supports bodies inside components) |
 | `export_step` | Export body as STEP (supports bodies inside components) |
 | `export_f3d` | Export design as Fusion archive |
+| `export` | Unified dispatcher — routes to `export_stl`/`export_step`/`export_f3d` based on explicit `format` or file-extension inference |
 
 ### CAM / Manufacturing
 | Tool | Description |

--- a/addon/Fusion360MCP.py
+++ b/addon/Fusion360MCP.py
@@ -4,8 +4,14 @@ Fusion360MCP Add-in (v2)
 Registers a CustomEvent so all Fusion API calls run on the main thread.
 A TCP socket server (daemon thread) accepts JSON commands and dispatches
 them through an EventBridge.
+
+Host/port override via env vars FUSION_MCP_HOST and FUSION_MCP_PORT.
+Set FUSION_MCP_HOST=0.0.0.0 to expose the add-in on all interfaces
+for cross-machine setups (MCP server on a different host). Only do
+this on a trusted LAN — the socket has no authentication.
 """
 
+import os
 import traceback
 
 import adsk.core
@@ -35,13 +41,19 @@ def run(context):
 
         _log = get_logger("main")
 
+        host = os.environ.get("FUSION_MCP_HOST", "localhost")
+        port = int(os.environ.get("FUSION_MCP_PORT", "9876"))
+
         _handler = CommandHandler()
         _bridge = EventBridge(_app, _handler)
-        _server = Fusion360MCPServer(_bridge, host="localhost", port=9876)
+        _server = Fusion360MCPServer(_bridge, host=host, port=port)
         _server.start()
 
-        _log.info("Fusion360MCP loaded - server on localhost:9876  "
-                   "(log: %s)", LOG_PATH)
+        _log.info("Fusion360MCP loaded - server on %s:%s  (log: %s)",
+                  host, port, LOG_PATH)
+        if host not in ("localhost", "127.0.0.1"):
+            _log.warning("Listening on non-loopback host %s — "
+                         "ensure this is a trusted LAN (no auth).", host)
 
     except Exception:
         msg = traceback.format_exc()

--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -155,6 +155,7 @@ class CommandHandler:
                 "export_step": self.export_step,
                 "export_f3d": self.export_f3d,
                 "export_view_sheet": self.export_view_sheet,
+                "import_mesh": self.import_mesh,
                 "boolean_operation": self.boolean_operation,
                 "delete_all": self.delete_all,
                 "undo": self.undo,
@@ -1703,6 +1704,47 @@ class CommandHandler:
             "views": rendered,
             "title": sheet_title,
             "image_size": [width, height],
+        }
+
+    def import_mesh(self, file_path: str, component_name: str = None,
+                    units: str = "mm"):
+        """Import mesh file (STL/OBJ/3MF) as mesh body. Values returned in cm."""
+        if not os.path.exists(file_path):
+            raise RuntimeError(f"Mesh file not found: {file_path}")
+
+        target = (self._component_by_name(component_name)
+                  if component_name else self._root())
+
+        unit_map = {
+            "mm": adsk.fusion.MeshUnits.MillimeterMeshUnit,
+            "cm": adsk.fusion.MeshUnits.CentimeterMeshUnit,
+            "m":  adsk.fusion.MeshUnits.MeterMeshUnit,
+            "in": adsk.fusion.MeshUnits.InchMeshUnit,
+            "ft": adsk.fusion.MeshUnits.FootMeshUnit,
+        }
+        if units not in unit_map:
+            raise RuntimeError(
+                f"Unknown units '{units}'. "
+                f"Expected one of: {sorted(unit_map)}")
+
+        mesh_body = target.meshBodies.addByFile(file_path, unit_map[units])
+
+        bb = mesh_body.boundingBox
+        return {
+            "imported": True,
+            "file_path": file_path,
+            "mesh_name": mesh_body.name,
+            "component": target.name,
+            "units": units,
+            "bounding_box": {
+                "min": [bb.minPoint.x, bb.minPoint.y, bb.minPoint.z],
+                "max": [bb.maxPoint.x, bb.maxPoint.y, bb.maxPoint.z],
+                "size": [
+                    bb.maxPoint.x - bb.minPoint.x,
+                    bb.maxPoint.y - bb.minPoint.y,
+                    bb.maxPoint.z - bb.minPoint.z,
+                ],
+            },
         }
 
     def boolean_operation(

--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -155,6 +155,7 @@ class CommandHandler:
                 "export_step": self.export_step,
                 "export_f3d": self.export_f3d,
                 "export_view_sheet": self.export_view_sheet,
+                "export": self.export,
                 "import_mesh": self.import_mesh,
                 "create_box_parametric": self.create_box_parametric,
                 "boolean_operation": self.boolean_operation,
@@ -1492,6 +1493,7 @@ class CommandHandler:
 
         return {"exported": True, "file_path": file_path}
 
+<<<<<<< HEAD
     # ── view sheet ─────────────────────────────────────────────────────
     # Render canonical views (iso/front/top/right/...) as PNGs and emit
     # a self-contained HTML page suitable for print-to-PDF. Intended
@@ -1706,6 +1708,30 @@ class CommandHandler:
             "title": sheet_title,
             "image_size": [width, height],
         }
+
+    def export(self, format: str = None, body_name: str = None,
+               file_path: str = None):
+        """Unified export — dispatches to export_stl/export_step/export_f3d."""
+        fmt = format.lower() if format else None
+        if not fmt and file_path:
+            fmt = os.path.splitext(file_path)[1].lstrip(".").lower()
+        if not fmt:
+            raise RuntimeError(
+                "Specify format (stl/step/f3d) or file_path with extension")
+
+        if fmt == "stl":
+            if not body_name:
+                raise RuntimeError("body_name required for STL export")
+            return self.export_stl(body_name, file_path)
+        if fmt in ("step", "stp"):
+            if not body_name:
+                raise RuntimeError("body_name required for STEP export")
+            return self.export_step(body_name, file_path)
+        if fmt == "f3d":
+            return self.export_f3d(file_path)
+
+        raise RuntimeError(
+            f"Unknown format: {fmt}. Expected: stl, step, f3d")
 
     def import_mesh(self, file_path: str, component_name: str = None,
                     units: str = "mm"):

--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -112,6 +112,7 @@ class CommandHandler:
                 # scene / query
                 "get_scene_info": self.get_scene_info,
                 "get_object_info": self.get_object_info,
+                "get_bounding_box": self.get_bounding_box,
                 "list_components": self.list_components,
                 # sketch
                 "create_sketch": self.create_sketch,
@@ -511,6 +512,58 @@ class CommandHandler:
                 }
             )
         return {"components": components, "count": len(components)}
+
+    def get_bounding_box(self, name: str):
+        """Axis-aligned bounding box for a body or component. Values in cm."""
+        def _payload(obj_type, mn, mx):
+            return {
+                "found": True, "type": obj_type, "name": name,
+                "min": mn, "max": mx,
+                "size": [mx[i] - mn[i] for i in range(3)],
+                "center": [(mn[i] + mx[i]) / 2 for i in range(3)],
+            }
+
+        # Try body first (covers root bodies + bodies inside components)
+        try:
+            body = self._body_by_name(name)
+            bb = body.boundingBox
+            return _payload(
+                "body",
+                [bb.minPoint.x, bb.minPoint.y, bb.minPoint.z],
+                [bb.maxPoint.x, bb.maxPoint.y, bb.maxPoint.z],
+            )
+        except RuntimeError:
+            pass
+
+        # Fall back to component: union bbox of all contained bodies
+        try:
+            comp = self._component_by_name(name)
+        except RuntimeError:
+            return {"found": False, "name": name}
+
+        mn = [float("inf")] * 3
+        mx = [float("-inf")] * 3
+
+        def _extend(bodies):
+            for i in range(bodies.count):
+                bb = bodies.item(i).boundingBox
+                lo = [bb.minPoint.x, bb.minPoint.y, bb.minPoint.z]
+                hi = [bb.maxPoint.x, bb.maxPoint.y, bb.maxPoint.z]
+                for axis in range(3):
+                    if lo[axis] < mn[axis]:
+                        mn[axis] = lo[axis]
+                    if hi[axis] > mx[axis]:
+                        mx[axis] = hi[axis]
+
+        _extend(comp.bRepBodies)
+        for occ in comp.allOccurrences:
+            _extend(occ.bRepBodies)
+
+        if mn[0] == float("inf"):
+            return {"found": True, "type": "component",
+                    "name": name, "empty": True}
+
+        return _payload("component", mn, mx)
 
     # ------------------------------------------------------------------
     # Sketch

--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -518,10 +518,14 @@ class CommandHandler:
 
     def get_bounding_box(self, name: str):
         """Axis-aligned bounding box for a body or component. Values in cm."""
+
         def _payload(obj_type, mn, mx):
             return {
-                "found": True, "type": obj_type, "name": name,
-                "min": mn, "max": mx,
+                "found": True,
+                "type": obj_type,
+                "name": name,
+                "min": mn,
+                "max": mx,
                 "size": [mx[i] - mn[i] for i in range(3)],
                 "center": [(mn[i] + mx[i]) / 2 for i in range(3)],
             }
@@ -563,8 +567,7 @@ class CommandHandler:
             _extend(occ.bRepBodies)
 
         if mn[0] == float("inf"):
-            return {"found": True, "type": "component",
-                    "name": name, "empty": True}
+            return {"found": True, "type": "component", "name": name, "empty": True}
 
         return _payload("component", mn, mx)
 
@@ -1708,15 +1711,15 @@ class CommandHandler:
             "image_size": [width, height],
         }
 
-    def export(self, format: str = None, body_name: str = None,
-               file_path: str = None):
+    def export(self, format: str = None, body_name: str = None, file_path: str = None):
         """Unified export — dispatches to export_stl/export_step/export_f3d."""
         fmt = format.lower() if format else None
         if not fmt and file_path:
             fmt = os.path.splitext(file_path)[1].lstrip(".").lower()
         if not fmt:
             raise RuntimeError(
-                "Specify format (stl/step/f3d) or file_path with extension")
+                "Specify format (stl/step/f3d) or file_path with extension"
+            )
 
         if fmt == "stl":
             if not body_name:
@@ -1729,29 +1732,30 @@ class CommandHandler:
         if fmt == "f3d":
             return self.export_f3d(file_path)
 
-        raise RuntimeError(
-            f"Unknown format: {fmt}. Expected: stl, step, f3d")
+        raise RuntimeError(f"Unknown format: {fmt}. Expected: stl, step, f3d")
 
-    def import_mesh(self, file_path: str, component_name: str = None,
-                    units: str = "mm"):
+    def import_mesh(
+        self, file_path: str, component_name: str = None, units: str = "mm"
+    ):
         """Import mesh file (STL/OBJ/3MF) as mesh body. Values returned in cm."""
         if not os.path.exists(file_path):
             raise RuntimeError(f"Mesh file not found: {file_path}")
 
-        target = (self._component_by_name(component_name)
-                  if component_name else self._root())
+        target = (
+            self._component_by_name(component_name) if component_name else self._root()
+        )
 
         unit_map = {
             "mm": adsk.fusion.MeshUnits.MillimeterMeshUnit,
             "cm": adsk.fusion.MeshUnits.CentimeterMeshUnit,
-            "m":  adsk.fusion.MeshUnits.MeterMeshUnit,
+            "m": adsk.fusion.MeshUnits.MeterMeshUnit,
             "in": adsk.fusion.MeshUnits.InchMeshUnit,
             "ft": adsk.fusion.MeshUnits.FootMeshUnit,
         }
         if units not in unit_map:
             raise RuntimeError(
-                f"Unknown units '{units}'. "
-                f"Expected one of: {sorted(unit_map)}")
+                f"Unknown units '{units}'. Expected one of: {sorted(unit_map)}"
+            )
 
         mesh_body = target.meshBodies.addByFile(file_path, unit_map[units])
 
@@ -1877,21 +1881,27 @@ class CommandHandler:
 
         return {"created": True, "length": length, "width": width, "height": height}
 
-    def create_box_parametric(self, length, width, height,
-                              origin_x: float = 0.0,
-                              origin_y: float = 0.0,
-                              origin_z: float = 0.0,
-                              plane: str = "xy",
-                              component_name: str = None,
-                              body_name: str = None):
+    def create_box_parametric(
+        self,
+        length,
+        width,
+        height,
+        origin_x: float = 0.0,
+        origin_y: float = 0.0,
+        origin_z: float = 0.0,
+        plane: str = "xy",
+        component_name: str = None,
+        body_name: str = None,
+    ):
         """Parametric box: sketch rectangle + dimensions + extrude.
 
         length/width/height may be numeric (cm) or string expressions
         (e.g. 'boxL', '56 mm'). Expressions are applied via Fusion's
         parameter system so later changes to User Parameters propagate.
         """
-        comp = (self._component_by_name(component_name)
-                if component_name else self._root())
+        comp = (
+            self._component_by_name(component_name) if component_name else self._root()
+        )
 
         base_plane = self._construction_plane(plane)
         if origin_z != 0:
@@ -1908,8 +1918,8 @@ class CommandHandler:
 
         p1 = adsk.core.Point3D.create(origin_x, origin_y, 0)
         p2 = adsk.core.Point3D.create(
-            origin_x + _initial(length),
-            origin_y + _initial(width), 0)
+            origin_x + _initial(length), origin_y + _initial(width), 0
+        )
         rect = sketch.sketchCurves.sketchLines.addTwoPointRectangle(p1, p2)
 
         dims = sketch.sketchDimensions
@@ -1923,16 +1933,20 @@ class CommandHandler:
 
         bottom = rect.item(0)
         length_dim = dims.addDistanceDimension(
-            bottom.startSketchPoint, bottom.endSketchPoint,
+            bottom.startSketchPoint,
+            bottom.endSketchPoint,
             adsk.fusion.DimensionOrientations.HorizontalDimensionOrientation,
-            text_pt)
+            text_pt,
+        )
         _set_dim(length_dim, length)
 
         right = rect.item(1)
         width_dim = dims.addDistanceDimension(
-            right.startSketchPoint, right.endSketchPoint,
+            right.startSketchPoint,
+            right.endSketchPoint,
             adsk.fusion.DimensionOrientations.VerticalDimensionOrientation,
-            text_pt)
+            text_pt,
+        )
         _set_dim(width_dim, width)
 
         if sketch.profiles.count == 0:
@@ -1941,8 +1955,8 @@ class CommandHandler:
 
         ext_feats = comp.features.extrudeFeatures
         ext_input = ext_feats.createInput(
-            profile,
-            adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
+            profile, adsk.fusion.FeatureOperations.NewBodyFeatureOperation
+        )
         if isinstance(height, (int, float)):
             h_vi = adsk.core.ValueInput.createByReal(float(height))
         else:

--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -1493,7 +1493,6 @@ class CommandHandler:
 
         return {"exported": True, "file_path": file_path}
 
-<<<<<<< HEAD
     # ── view sheet ─────────────────────────────────────────────────────
     # Render canonical views (iso/front/top/right/...) as PNGs and emit
     # a self-contained HTML page suitable for print-to-PDF. Intended

--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -156,6 +156,7 @@ class CommandHandler:
                 "export_f3d": self.export_f3d,
                 "export_view_sheet": self.export_view_sheet,
                 "import_mesh": self.import_mesh,
+                "create_box_parametric": self.create_box_parametric,
                 "boolean_operation": self.boolean_operation,
                 "delete_all": self.delete_all,
                 "undo": self.undo,
@@ -1850,6 +1851,96 @@ class CommandHandler:
         base_feat.finishEdit()
 
         return {"created": True, "length": length, "width": width, "height": height}
+
+    def create_box_parametric(self, length, width, height,
+                              origin_x: float = 0.0,
+                              origin_y: float = 0.0,
+                              origin_z: float = 0.0,
+                              plane: str = "xy",
+                              component_name: str = None,
+                              body_name: str = None):
+        """Parametric box: sketch rectangle + dimensions + extrude.
+
+        length/width/height may be numeric (cm) or string expressions
+        (e.g. 'boxL', '56 mm'). Expressions are applied via Fusion's
+        parameter system so later changes to User Parameters propagate.
+        """
+        comp = (self._component_by_name(component_name)
+                if component_name else self._root())
+
+        base_plane = self._construction_plane(plane)
+        if origin_z != 0:
+            plane_input = comp.constructionPlanes.createInput()
+            offset_val = adsk.core.ValueInput.createByReal(origin_z)
+            plane_input.setByOffset(base_plane, offset_val)
+            sketch_plane = comp.constructionPlanes.add(plane_input)
+        else:
+            sketch_plane = base_plane
+        sketch = comp.sketches.add(sketch_plane)
+
+        def _initial(val):
+            return float(val) if isinstance(val, (int, float)) else 1.0
+
+        p1 = adsk.core.Point3D.create(origin_x, origin_y, 0)
+        p2 = adsk.core.Point3D.create(
+            origin_x + _initial(length),
+            origin_y + _initial(width), 0)
+        rect = sketch.sketchCurves.sketchLines.addTwoPointRectangle(p1, p2)
+
+        dims = sketch.sketchDimensions
+        text_pt = adsk.core.Point3D.create(0, 0, 0)
+
+        def _set_dim(dim, value):
+            if isinstance(value, (int, float)):
+                dim.parameter.value = float(value)
+            else:
+                dim.parameter.expression = str(value)
+
+        bottom = rect.item(0)
+        length_dim = dims.addDistanceDimension(
+            bottom.startSketchPoint, bottom.endSketchPoint,
+            adsk.fusion.DimensionOrientations.HorizontalDimensionOrientation,
+            text_pt)
+        _set_dim(length_dim, length)
+
+        right = rect.item(1)
+        width_dim = dims.addDistanceDimension(
+            right.startSketchPoint, right.endSketchPoint,
+            adsk.fusion.DimensionOrientations.VerticalDimensionOrientation,
+            text_pt)
+        _set_dim(width_dim, width)
+
+        if sketch.profiles.count == 0:
+            raise RuntimeError("Rectangle sketch produced no profile")
+        profile = sketch.profiles.item(0)
+
+        ext_feats = comp.features.extrudeFeatures
+        ext_input = ext_feats.createInput(
+            profile,
+            adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
+        if isinstance(height, (int, float)):
+            h_vi = adsk.core.ValueInput.createByReal(float(height))
+        else:
+            h_vi = adsk.core.ValueInput.createByString(str(height))
+        ext_input.setDistanceExtent(False, h_vi)
+        feat = ext_feats.add(ext_input)
+
+        body = feat.bodies.item(0)
+        if body_name:
+            body.name = body_name
+
+        return {
+            "created": True,
+            "body_name": body.name,
+            "feature_name": feat.name,
+            "sketch_name": sketch.name,
+            "length": length,
+            "width": width,
+            "height": height,
+            "origin": [origin_x, origin_y, origin_z],
+            "plane": plane,
+            "component": comp.name,
+        }
 
     def create_cylinder(
         self,

--- a/src/fusion360_mcp/connection.py
+++ b/src/fusion360_mcp/connection.py
@@ -1,19 +1,23 @@
 """
 TCP connection to the Fusion360MCP add-in running inside Fusion 360.
 
-The add-in listens on localhost:9876 and speaks newline-delimited JSON.
+The add-in listens on localhost:9876 by default and speaks
+newline-delimited JSON. Override via env vars FUSION_MCP_HOST /
+FUSION_MCP_PORT for cross-machine setups (e.g. MCP server on a
+Mac Mini connecting to Fusion running on a Windows PC).
 """
 
 import json
 import logging
+import os
 import socket
 import time
 from typing import Any
 
 log = logging.getLogger("fusion360_mcp.connection")
 
-_DEFAULT_HOST = "localhost"
-_DEFAULT_PORT = 9876
+_DEFAULT_HOST = os.environ.get("FUSION_MCP_HOST", "localhost")
+_DEFAULT_PORT = int(os.environ.get("FUSION_MCP_PORT", "9876"))
 _RECV_BUF = 65536
 _TIMEOUT = 30.0  # matches the add-in's bridge timeout
 _PING_TIMEOUT = 5.0

--- a/src/fusion360_mcp/mock.py
+++ b/src/fusion360_mcp/mock.py
@@ -381,6 +381,20 @@ def _export_view_sheet(p: dict) -> dict:
     }
 
 
+def _export(p: dict) -> dict:
+    fmt = (p.get("format") or "").lower()
+    path = p.get("file_path", "")
+    if not fmt and path:
+        fmt = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+    name = p.get("body_name", "Body1")
+    return {
+        "exported": True,
+        "format": fmt or "f3d",
+        "body": name,
+        "file_path": path or f"~/Desktop/{name}.{fmt or 'f3d'}",
+    }
+
+
 def _import_mesh(p: dict) -> dict:
     path = p.get("file_path", "/tmp/mesh.stl")
     units = p.get("units", "mm")
@@ -939,6 +953,7 @@ _DISPATCH: dict[str, Any] = {
     "export_step": _export_step,
     "export_f3d": _export_f3d,
     "export_view_sheet": _export_view_sheet,
+    "export": _export,
     "import_mesh": _import_mesh,
     "create_box_parametric": _create_box_parametric,
     "get_parameters": _get_parameters,

--- a/src/fusion360_mcp/mock.py
+++ b/src/fusion360_mcp/mock.py
@@ -399,6 +399,25 @@ def _import_mesh(p: dict) -> dict:
     }
 
 
+def _create_box_parametric(p: dict) -> dict:
+    return {
+        "created": True,
+        "body_name": p.get("body_name") or "BoxParametric_mock",
+        "feature_name": "Extrude_mock",
+        "sketch_name": "Sketch_mock",
+        "length": p.get("length", 1),
+        "width": p.get("width", 1),
+        "height": p.get("height", 1),
+        "origin": [
+            p.get("origin_x", 0),
+            p.get("origin_y", 0),
+            p.get("origin_z", 0),
+        ],
+        "plane": p.get("plane", "xy"),
+        "component": p.get("component_name") or "RootComponent",
+    }
+
+
 # ── parameter tools ───────────────────────────────────────────────────
 
 
@@ -921,6 +940,7 @@ _DISPATCH: dict[str, Any] = {
     "export_f3d": _export_f3d,
     "export_view_sheet": _export_view_sheet,
     "import_mesh": _import_mesh,
+    "create_box_parametric": _create_box_parametric,
     "get_parameters": _get_parameters,
     "create_parameter": _create_parameter,
     "set_parameter": _set_parameter,

--- a/src/fusion360_mcp/mock.py
+++ b/src/fusion360_mcp/mock.py
@@ -381,6 +381,24 @@ def _export_view_sheet(p: dict) -> dict:
     }
 
 
+def _import_mesh(p: dict) -> dict:
+    path = p.get("file_path", "/tmp/mesh.stl")
+    units = p.get("units", "mm")
+    component = p.get("component_name") or "RootComponent"
+    return {
+        "imported": True,
+        "file_path": path,
+        "mesh_name": "MeshBody_mock",
+        "component": component,
+        "units": units,
+        "bounding_box": {
+            "min": [0.0, 0.0, 0.0],
+            "max": [10.0, 5.0, 2.0],
+            "size": [10.0, 5.0, 2.0],
+        },
+    }
+
+
 # ── parameter tools ───────────────────────────────────────────────────
 
 
@@ -902,6 +920,7 @@ _DISPATCH: dict[str, Any] = {
     "export_step": _export_step,
     "export_f3d": _export_f3d,
     "export_view_sheet": _export_view_sheet,
+    "import_mesh": _import_mesh,
     "get_parameters": _get_parameters,
     "create_parameter": _create_parameter,
     "set_parameter": _set_parameter,

--- a/src/fusion360_mcp/mock.py
+++ b/src/fusion360_mcp/mock.py
@@ -130,6 +130,19 @@ def _get_object_info(p: dict) -> dict:
     }
 
 
+def _get_bounding_box(p: dict) -> dict:
+    name = p.get("name", "Unknown")
+    return {
+        "found": True,
+        "type": "body",
+        "name": name,
+        "min": [0.0, 0.0, 0.0],
+        "max": [50.0, 30.0, 15.0],
+        "size": [50.0, 30.0, 15.0],
+        "center": [25.0, 15.0, 7.5],
+    }
+
+
 def _create_sketch(p: dict) -> dict:
     plane = p.get("plane", "xy")
     return {"sketch_name": f"Sketch_mock_{plane}", "plane": plane}
@@ -858,6 +871,7 @@ _DISPATCH: dict[str, Any] = {
     "ping": _ping,
     "get_scene_info": _get_scene_info,
     "get_object_info": _get_object_info,
+    "get_bounding_box": _get_bounding_box,
     "create_sketch": _create_sketch,
     "draw_rectangle": _draw_rectangle,
     "draw_circle": _draw_circle,

--- a/src/fusion360_mcp/server.py
+++ b/src/fusion360_mcp/server.py
@@ -7,6 +7,7 @@ Supports ``--mode mock`` for testing without Fusion running.
 
 import json
 import logging
+import os
 import re
 
 import anyio
@@ -29,12 +30,13 @@ def _send(
     command_type: str,
     params: dict | None = None,
     *,
+    host: str = "localhost",
     port: int = 9876,
 ) -> dict:
     """Route a command through either the real TCP connection or mock."""
     if mode == "mock":
         return mock_command(command_type, params)
-    conn = get_connection(port=port)
+    conn = get_connection(host=host, port=port)
     return conn.send_command(command_type, params)
 
 
@@ -143,9 +145,21 @@ def _format_result(
     help="'socket' connects to Fusion, 'mock' returns test data",
 )
 @click.option(
-    "--port", type=int, default=9876, help="TCP port the Fusion 360 add-in listens on"
+    "--host",
+    type=str,
+    default=lambda: os.environ.get("FUSION_MCP_HOST", "localhost"),
+    help=(
+        "Host where the Fusion 360 add-in listens (env: FUSION_MCP_HOST). "
+        "Use the Windows LAN IP when the MCP server runs on a different machine."
+    ),
 )
-def main(mode: str, port: int) -> int:
+@click.option(
+    "--port",
+    type=int,
+    default=lambda: int(os.environ.get("FUSION_MCP_PORT", "9876")),
+    help="TCP port the Fusion 360 add-in listens on (env: FUSION_MCP_PORT)",
+)
+def main(mode: str, host: str, port: int) -> int:
     """Fusion360 MCP Server — connects Claude to Fusion 360."""
 
     app = Server("fusion360-mcp-server")
@@ -166,7 +180,7 @@ def main(mode: str, port: int) -> int:
             raise ValueError(f"Unknown tool: {name}")
 
         try:
-            result = _send(mode, name, arguments, port=port)
+            result = _send(mode, name, arguments, host=host, port=port)
         except Exception as exc:
             reset_connection()
             content = [

--- a/src/fusion360_mcp/tools.py
+++ b/src/fusion360_mcp/tools.py
@@ -1342,6 +1342,64 @@ TOOLS: list[dict] = [
         },
     },
     {
+        "name": "create_box_parametric",
+        "title": "Create Parametric Box",
+        "description": (
+            "Create a history-based rectangular box via sketch rectangle + "
+            "extrude (unlike create_box which uses TemporaryBRepManager). "
+            "length/width/height accept a number (cm, Fusion internal unit) "
+            "or a string expression referencing User Parameters "
+            "(e.g. 'boxL', '56 mm', 'outer - 2 * wall_t'). "
+            "Call create_parameter first to define named parameters."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "required": ["length", "width", "height"],
+            "properties": {
+                "length": {
+                    "oneOf": [
+                        {"type": "number", "minimum": 0.001},
+                        {"type": "string"},
+                    ],
+                    "description": "Along sketch X: number (cm) or expression",
+                },
+                "width": {
+                    "oneOf": [
+                        {"type": "number", "minimum": 0.001},
+                        {"type": "string"},
+                    ],
+                    "description": "Along sketch Y: number (cm) or expression",
+                },
+                "height": {
+                    "oneOf": [
+                        {"type": "number", "minimum": 0.001},
+                        {"type": "string"},
+                    ],
+                    "description": "Extrude distance: number (cm) or expression",
+                },
+                "origin_x": {"type": "number", "default": 0},
+                "origin_y": {"type": "number", "default": 0},
+                "origin_z": {
+                    "type": "number", "default": 0,
+                    "description": "Z-offset of sketch plane (cm)",
+                },
+                "plane": {
+                    "type": "string",
+                    "enum": ["xy", "yz", "xz"],
+                    "default": "xy",
+                },
+                "component_name": {
+                    "type": "string",
+                    "description": "Target component (omit for root)",
+                },
+                "body_name": {
+                    "type": "string",
+                    "description": "Optional name for the resulting body",
+                },
+            },
+        },
+    },
+    {
         "name": "create_cylinder",
         "title": "Create Cylinder",
         "description": (

--- a/src/fusion360_mcp/tools.py
+++ b/src/fusion360_mcp/tools.py
@@ -654,6 +654,39 @@ TOOLS: list[dict] = [
             },
         },
     },
+    {
+        "name": "export",
+        "title": "Export (unified)",
+        "description": (
+            "Unified export wrapper — dispatches to export_stl / export_step / "
+            "export_f3d based on format or file extension. "
+            "Format is auto-detected from file_path extension if not specified. "
+            "STL and STEP require body_name; F3D exports the whole design."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "format": {
+                    "type": "string",
+                    "enum": ["stl", "step", "stp", "f3d"],
+                    "description": (
+                        "Output format. Inferred from file_path extension "
+                        "if omitted."
+                    ),
+                },
+                "body_name": {
+                    "type": "string",
+                    "description": "Body to export (required for stl/step)",
+                },
+                "file_path": {
+                    "type": "string",
+                    "description": (
+                        "Destination path (default: ~/Desktop/<name>.<ext>)"
+                    ),
+                },
+            },
+        },
+    },
     # ── import ─────────────────────────────────────────────────────────
     {
         "name": "import_mesh",

--- a/src/fusion360_mcp/tools.py
+++ b/src/fusion360_mcp/tools.py
@@ -654,6 +654,38 @@ TOOLS: list[dict] = [
             },
         },
     },
+    # ── import ─────────────────────────────────────────────────────────
+    {
+        "name": "import_mesh",
+        "title": "Import Mesh",
+        "description": (
+            "Import a mesh file (STL, OBJ, or 3MF) as a mesh body. "
+            "Returns the mesh name and bounding box. "
+            "Use for reference geometry (e.g. exported SketchUp model)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "required": ["file_path"],
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Absolute path to mesh file (.stl/.obj/.3mf)",
+                },
+                "component_name": {
+                    "type": "string",
+                    "description": (
+                        "Target component name (omit for root component)"
+                    ),
+                },
+                "units": {
+                    "type": "string",
+                    "enum": ["mm", "cm", "m", "in", "ft"],
+                    "default": "mm",
+                    "description": "Source mesh units (default: mm)",
+                },
+            },
+        },
+    },
     # ── parameters ─────────────────────────────────────────────────────
     {
         "name": "get_parameters",

--- a/src/fusion360_mcp/tools.py
+++ b/src/fusion360_mcp/tools.py
@@ -30,6 +30,26 @@ TOOLS: list[dict] = [
             },
         },
     },
+    {
+        "name": "get_bounding_box",
+        "title": "Get Bounding Box",
+        "description": (
+            "Axis-aligned bounding box for a body or component by name. "
+            "Returns min, max, size, and center in cm (Fusion internal units). "
+            "For components, unions bounding boxes of all contained bodies. "
+            "Useful for measuring imported reference geometry."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Body or component name",
+                },
+            },
+        },
+    },
     # ── sketch ───────────────────────────────────────────────────────
     {
         "name": "create_sketch",
@@ -2147,6 +2167,7 @@ TOOLS: list[dict] = [
 _READ_ONLY = {
     "get_scene_info",
     "get_object_info",
+    "get_bounding_box",
     "list_components",
     "get_parameters",
     "get_physical_properties",
@@ -2165,6 +2186,7 @@ _IDEMPOTENT = {
     "ping",
     "get_scene_info",
     "get_object_info",
+    "get_bounding_box",
     "list_components",
     "get_parameters",
     "get_physical_properties",

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -64,6 +64,25 @@ class TestMockSceneQuery:
         assert "mesh_name" in result
         assert "bounding_box" in result
 
+    def test_create_box_parametric_numeric(self):
+        result = mock_command("create_box_parametric", {
+            "length": 56, "width": 30, "height": 25,
+        })
+        assert result["created"] is True
+        assert result["length"] == 56
+        assert "body_name" in result
+        assert "sketch_name" in result
+
+    def test_create_box_parametric_expression(self):
+        result = mock_command("create_box_parametric", {
+            "length": "boxL",
+            "width": "boxW",
+            "height": "boxH - wall_t",
+            "body_name": "BoxRechts",
+        })
+        assert result["body_name"] == "BoxRechts"
+        assert result["height"] == "boxH - wall_t"
+
 
 class TestMockSketch:
     def test_create_sketch(self):

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -53,6 +53,17 @@ class TestMockSceneQuery:
         assert len(result["size"]) == 3
         assert len(result["center"]) == 3
 
+    def test_import_mesh(self):
+        result = mock_command("import_mesh", {
+            "file_path": "/tmp/wheel_arch.stl",
+            "units": "mm",
+        })
+        assert result["imported"] is True
+        assert result["file_path"] == "/tmp/wheel_arch.stl"
+        assert result["units"] == "mm"
+        assert "mesh_name" in result
+        assert "bounding_box" in result
+
 
 class TestMockSketch:
     def test_create_sketch(self):

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -45,6 +45,14 @@ class TestMockSceneQuery:
         assert result["name"] == "TestBody"
         assert "faces" in result
 
+    def test_get_bounding_box(self):
+        result = mock_command("get_bounding_box", {"name": "TestBody"})
+        assert result["name"] == "TestBody"
+        assert result["found"] is True
+        assert result["min"] == [0.0, 0.0, 0.0]
+        assert len(result["size"]) == 3
+        assert len(result["center"]) == 3
+
 
 class TestMockSketch:
     def test_create_sketch(self):

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -83,6 +83,22 @@ class TestMockSceneQuery:
         assert result["body_name"] == "BoxRechts"
         assert result["height"] == "boxH - wall_t"
 
+    def test_export_unified_infers_format(self):
+        result = mock_command("export", {
+            "body_name": "BoxRechts",
+            "file_path": "/tmp/BoxRechts.step",
+        })
+        assert result["exported"] is True
+        assert result["format"] == "step"
+        assert result["body"] == "BoxRechts"
+
+    def test_export_unified_explicit_format(self):
+        result = mock_command("export", {
+            "format": "stl",
+            "body_name": "Part1",
+        })
+        assert result["format"] == "stl"
+
 
 class TestMockSketch:
     def test_create_sketch(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -94,6 +94,7 @@ class TestToolAnnotations:
         read_only_names = {
             "get_scene_info",
             "get_object_info",
+            "get_bounding_box",
             "list_components",
             "get_parameters",
             "get_physical_properties",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -103,6 +103,7 @@ def test_expected_tools_present():
         "export_step",
         "export_f3d",
         "export_view_sheet",
+        "export",
         # import
         "import_mesh",
         # parameters

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -63,6 +63,7 @@ def test_expected_tools_present():
         # scene / query
         "get_scene_info",
         "get_object_info",
+        "get_bounding_box",
         # sketch
         "create_sketch",
         "draw_rectangle",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -134,6 +134,7 @@ def test_expected_tools_present():
         "create_cylinder",
         "create_sphere",
         "create_torus",
+        "create_box_parametric",
         # assembly (extended)
         "create_as_built_joint",
         "create_rigid_group",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -103,6 +103,8 @@ def test_expected_tools_present():
         "export_step",
         "export_f3d",
         "export_view_sheet",
+        # import
+        "import_mesh",
         # parameters
         "get_parameters",
         "create_parameter",


### PR DESCRIPTION
## Summary

Four new tools oriented at a common CAD workflow — bringing in reference geometry (mesh from SketchUp or a scanner), measuring it, and constructing parametric geometry around it — plus cross-machine LAN support so the MCP server and Fusion can run on different hosts.

### New tools
- **`get_bounding_box`** — axis-aligned bounding box (min/max/size/center in cm) for a body or component. For components, unions contained bodies including nested occurrences.
- **`import_mesh`** — import STL/OBJ/3MF via `MeshBodies.addByFile()`. Unit-aware (`mm`/`cm`/`m`/`in`/`ft`). Returns the mesh name and bounding box.
- **`create_box_parametric`** — history-based box: sketch rectangle + sketch dimensions + extrude. `length`/`width`/`height` accept either a number (cm) or a string expression passed through Fusion's parameter system (e.g. ``"boxL"``, ``"outer - 2*wall_t"``) so later changes to User Parameters propagate.
- **`export`** — unified dispatcher around `export_stl` / `export_step` / `export_f3d` with format inference from file extension. Keeps the specialized tools unchanged.

### LAN / cross-machine support
- Add-in and client read `FUSION_MCP_HOST` / `FUSION_MCP_PORT` from the environment (defaults unchanged: `localhost:9876`).
- New `--host` CLI flag on the MCP server.
- Add-in logs a warning when binding to a non-loopback host — the socket has no auth, LAN-only.
- New README section documenting the setup.

### Fidelity to existing patterns
- Every new tool follows the 5-step add-recipe from `CLAUDE.md` (tool def in `tools.py`, handler in `command_handler.py`, mock handler + dispatch in `mock.py`, annotations, tests in `test_tools.py` + `test_mock.py` + `test_server.py`).
- `get_bounding_box` reuses the existing `_body_by_name` / `_component_by_name` helpers and the bounding-box payload format already used by `get_object_info`.
- `create_box_parametric` uses `ValueInput.createByString` when the caller passes an expression, falling back to `createByReal` for numeric input.
- All Fusion API units remain centimeters as documented.

## Test plan
- [x] `uv run pytest` → **262 passed** (254 before, +8 new / adjusted)
- [x] `uv run ruff check` → clean
- [ ] Install add-in on Fusion 360 and verify `ping` + each new tool end-to-end (pending — the author will test this in the coming days against a Mercedes G-Klasse wheel-arch model and report back; happy to split any failures into separate PRs)

Happy to iterate on naming, split into smaller PRs, or drop pieces if the scope doesn't fit the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)