### PR TITLE
Add devcontainer support for Docker-based MCP clients

### DIFF
--- a/devcontainer/README.md
+++ b/devcontainer/README.md
@@ -1,0 +1,141 @@
+# Devcontainer setup
+
+Run `fusion360-mcp-server` from inside a Docker devcontainer (e.g. VS Code's Dev Containers extension) while Fusion 360 runs on the Windows host.
+
+## The problem
+
+`fusion360-mcp-server` connects to `localhost:9876` to reach the Fusion add-in. From inside a Docker container, `localhost` is the container's own loopback — not the Windows host where Fusion is running. Three things stand in the way:
+
+1. The container's `localhost` does not reach the host
+2. The Fusion add-in binds to `127.0.0.1` on Windows, so even traffic that reaches the host gets dropped if it comes in on a different interface
+3. Windows Firewall blocks inbound traffic from the Docker subnet by default
+
+## The fix
+
+```
+Devcontainer
+  MCP client
+    └── spawns fusion-mcp-wrapper.sh (stdio MCP subprocess)
+         ├── Python TCP relay  localhost:9876 ──────────────────────┐
+         └── uvx fusion360-mcp-server  (connects to localhost:9876) ┘
+                                                                     │ relayed to
+                                                              host.docker.internal:9876
+                                                                     │
+Windows host (netsh portproxy)                                       │
+  Docker bridge IP:9876 ──forwards──► 127.0.0.1:9876 ◄───────────────┘
+                                            │
+                                     Fusion MCP add-in
+```
+
+Two scripts handle it:
+
+1. **`fusion-mcp-bridge.ps1`** (Windows-side, run once as Administrator) — adds `netsh portproxy` rules forwarding the Docker bridge adapter IPs to `127.0.0.1:9876`, plus a Windows Firewall inbound rule scoped to the Docker subnet only. Both rules persist across reboots.
+2. **`fusion-mcp-wrapper.sh`** (devcontainer-side, configured as your MCP client's stdio command) — starts a Python TCP relay forwarding the container's `localhost:9876` to `host.docker.internal:9876`, then execs `uvx fusion360-mcp-server --mode socket`. The MCP server connects to `localhost:9876` unchanged; the relay bridges it to the Windows host.
+
+## Setup
+
+### 1. Install the Fusion add-in (Windows)
+
+Follow the main README — copy the `addon` directory into Fusion's add-ins folder and start it via Shift+S → Add-Ins → Fusion360MCP → Run. Confirm in TEXT COMMANDS:
+
+```
+[MCP] Server listening on localhost:9876
+```
+
+### 2. Run the Windows bridge script (once, as Administrator)
+
+```powershell
+.\devcontainer\fusion-mcp-bridge.ps1
+```
+
+The script:
+1. Discovers Docker bridge adapter IPs (those in the 172.16–31.x range — avoids LAN/VPN adapters)
+2. Adds a `netsh portproxy` rule per adapter forwarding to `127.0.0.1:9876`
+3. Adds a Windows Firewall inbound rule scoped to those subnets
+
+Idempotent. Re-run after Docker network changes. To remove:
+
+```powershell
+.\devcontainer\fusion-mcp-bridge.ps1 -Remove
+```
+
+### 3. Verify connectivity from the devcontainer
+
+```bash
+python3 -c "
+import socket
+s = socket.socket()
+s.settimeout(3)
+s.connect(('host.docker.internal', 9876))
+print('OK')
+s.close()
+"
+```
+
+If you get `Connection refused`: Fusion add-in isn't running.  
+If you get `Connection timed out`: portproxy or firewall rule missing — re-run the bridge script.
+
+### 4. Configure your MCP client
+
+Point your MCP client's stdio command at the wrapper script (use an absolute path).
+
+**Claude Code (`.claude/settings.json`):**
+```json
+{
+  "mcpServers": {
+    "fusion": {
+      "command": "/absolute/path/to/devcontainer/fusion-mcp-wrapper.sh",
+      "args": []
+    }
+  }
+}
+```
+
+**VS Code MCP (`.vscode/mcp.json`):**
+```json
+{
+  "servers": {
+    "fusion": {
+      "type": "stdio",
+      "command": "/absolute/path/to/devcontainer/fusion-mcp-wrapper.sh"
+    }
+  }
+}
+```
+
+**Cursor (`~/.cursor/mcp.json`):**
+```json
+{
+  "mcpServers": {
+    "fusion": {
+      "command": "/absolute/path/to/devcontainer/fusion-mcp-wrapper.sh"
+    }
+  }
+}
+```
+
+### 5. Test
+
+Ask your MCP client to call the `ping` tool. If it returns `{"pong": true}`, you're connected end-to-end.
+
+## Prerequisites
+
+- **Docker Desktop** on Windows (the wrapper relies on `host.docker.internal`, which Docker Desktop populates automatically)
+- **`uv`** in the devcontainer (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
+- **Python 3.8+** in the devcontainer (for the TCP relay — uses only stdlib)
+- The wrapper script must be executable: `chmod +x devcontainer/fusion-mcp-wrapper.sh`
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| MCP client shows server disconnected | Wrapper failed to start | Run the wrapper manually (`bash devcontainer/fusion-mcp-wrapper.sh`) and check stderr |
+| `uvx: not found` | uv not installed in container | Install uv (see Prerequisites) |
+| Python relay error: address in use | Stale relay from a previous run | `lsof -ti:9876 \| xargs kill` |
+| TCP test: connection refused | Fusion add-in not running on host | Shift+S → Add-Ins → Fusion360MCP → Run |
+| TCP test: connection timed out | Bridge script not run, or firewall blocking | Re-run `fusion-mcp-bridge.ps1` as Administrator |
+| Bridge script: no Docker adapters found | Docker Desktop not running, or unusual network setup | Check `Get-NetIPAddress` shows a 172.16–31.x adapter |
+
+## Why not bind the add-in to 0.0.0.0?
+
+That would expose the Fusion API on every interface — including LAN and VPN adapters. The bridge approach scopes exposure to the Docker bridge subnet only, with a firewall rule that drops everything else.

--- a/devcontainer/fusion-mcp-bridge.ps1
+++ b/devcontainer/fusion-mcp-bridge.ps1
@@ -1,0 +1,163 @@
+#Requires -RunAsAdministrator
+<#
+.SYNOPSIS
+    Bridges the Fusion 360 MCP add-in from Windows localhost to the Docker/WSL2 container network.
+
+.DESCRIPTION
+    The Fusion MCP add-in binds to 127.0.0.1 on Windows. Docker containers reach the Windows
+    host via host.docker.internal, which the add-in never sees.
+
+    This script:
+      1. Creates netsh portproxy rules to forward each Docker bridge adapter IP:PORT -> 127.0.0.1:PORT
+      2. Adds a Windows Firewall inbound rule scoped to those Docker bridge subnets only
+
+    Binding to specific adapter IPs (not 0.0.0.0) means the LAN and VPN adapters never see
+    the port, even if the firewall rule were misconfigured.
+
+    Run once. Both rules are persistent (survive reboots). Re-running is safe (idempotent).
+
+.PARAMETER Port
+    Port the Fusion MCP add-in is listening on. Default: 9876.
+
+.PARAMETER Remove
+    Remove the portproxy and firewall rules instead of adding them.
+
+.EXAMPLE
+    .\fusion-mcp-bridge.ps1
+    .\fusion-mcp-bridge.ps1 -Port 9876
+    .\fusion-mcp-bridge.ps1 -Remove
+#>
+param(
+    [int]$Port = 9876,
+    [switch]$Remove
+)
+
+$FirewallRuleName = "Fusion MCP - Docker Container Bridge (port $Port)"
+
+# Discover Docker/WSL2 bridge adapter IPs at runtime.
+# Only the 172.16-31.x range is used to avoid including LAN/VPN adapters.
+# Compute proper network addresses (mask host bits) so Windows Firewall accepts them.
+function Get-NetworkAddress([string]$ip, [int]$prefix) {
+    $bytes = [System.Net.IPAddress]::Parse($ip).GetAddressBytes()
+    $mask = [uint32]([uint32]::MaxValue -shl (32 - $prefix))
+    $ipInt = ([uint32]$bytes[0] -shl 24) -bor ([uint32]$bytes[1] -shl 16) -bor ([uint32]$bytes[2] -shl 8) -bor [uint32]$bytes[3]
+    $netInt = $ipInt -band $mask
+    $net = [System.Net.IPAddress]::new([byte[]]@(($netInt -shr 24) -band 0xFF, ($netInt -shr 16) -band 0xFF, ($netInt -shr 8) -band 0xFF, $netInt -band 0xFF))
+    return "$net/$prefix"
+}
+
+$DockerAdapterIPs = @(
+    Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+    Where-Object { $_.IPAddress -match "^172\.(1[6-9]|2[0-9]|3[01])\." } |
+    ForEach-Object { Get-NetworkAddress $_.IPAddress $_.PrefixLength }
+)
+if (-not $DockerAdapterIPs) {
+    Write-Warning "No Docker bridge adapters found in 172.16-31.x range. Falling back to 172.16.0.0/12."
+    $DockerAdapterIPs = @("172.16.0.0/12")
+}
+
+if ($Remove) {
+    Write-Host "Removing Fusion MCP bridge rules for port $Port..." -ForegroundColor Yellow
+
+    netsh interface portproxy delete v4tov4 listenport=$Port listenaddress=0.0.0.0 2>$null
+    $removeIPs = @(
+        Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+        Where-Object { $_.IPAddress -match "^172\.(1[6-9]|2[0-9]|3[01])\." } |
+        ForEach-Object { $_.IPAddress }
+    )
+    foreach ($ip in $removeIPs) {
+        netsh interface portproxy delete v4tov4 listenport=$Port listenaddress=$ip 2>$null
+    }
+    Write-Host "  Portproxy rules removed (or were not present)"
+
+    $rule = Get-NetFirewallRule -DisplayName $FirewallRuleName -ErrorAction SilentlyContinue
+    if ($rule) {
+        Remove-NetFirewallRule -DisplayName $FirewallRuleName
+        Write-Host "  Firewall rule removed"
+    } else {
+        Write-Host "  Firewall rule was not present"
+    }
+
+    Write-Host "Done." -ForegroundColor Green
+    exit 0
+}
+
+Write-Host "Setting up Fusion MCP bridge for port $Port..." -ForegroundColor Cyan
+Write-Host ""
+
+# Step 1: portproxy rules (bind to the host's adapter IP, not the network address)
+$DockerHostIPs = @(
+    Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+    Where-Object { $_.IPAddress -match "^172\.(1[6-9]|2[0-9]|3[01])\." } |
+    ForEach-Object { $_.IPAddress }
+)
+if (-not $DockerHostIPs) { $DockerHostIPs = @() }
+
+$adapterList = $DockerHostIPs -join ", "
+Write-Host "[1/3] Adding portproxy rules ($adapterList -> 127.0.0.1:$Port)..."
+$proxyOk = $true
+foreach ($adapterIP in $DockerHostIPs) {
+    netsh interface portproxy add v4tov4 `
+        listenport=$Port `
+        listenaddress=$adapterIP `
+        connectport=$Port `
+        connectaddress=127.0.0.1
+    $pattern = [regex]::Escape($adapterIP)
+    $check = netsh interface portproxy show v4tov4 | Select-String $pattern
+    if ($check) {
+        Write-Host "  OK: ${adapterIP}:${Port} -> 127.0.0.1:${Port}" -ForegroundColor Green
+    } else {
+        Write-Host "  WARNING: rule for $adapterIP may not have been created" -ForegroundColor Yellow
+        $proxyOk = $false
+    }
+}
+if (-not $proxyOk) {
+    Write-Host "  Run 'netsh interface portproxy show v4tov4' to inspect" -ForegroundColor Yellow
+}
+
+# Step 2: Firewall rule scoped to Docker subnets only
+Write-Host "[2/3] Adding Windows Firewall inbound rule..."
+$existing = Get-NetFirewallRule -DisplayName $FirewallRuleName -ErrorAction SilentlyContinue
+if ($existing) {
+    Write-Host "  Rule already exists - removing and recreating to ensure correct config"
+    Remove-NetFirewallRule -DisplayName $FirewallRuleName
+}
+
+New-NetFirewallRule `
+    -DisplayName $FirewallRuleName `
+    -Direction Inbound `
+    -Protocol TCP `
+    -LocalPort $Port `
+    -RemoteAddress ($DockerAdapterIPs -join ",") `
+    -Action Allow `
+    -Profile Any | Out-Null
+
+$rule = Get-NetFirewallRule -DisplayName $FirewallRuleName -ErrorAction SilentlyContinue
+if ($rule) {
+    Write-Host "  OK: Firewall rule created" -ForegroundColor Green
+} else {
+    Write-Host "  ERROR: Firewall rule creation failed" -ForegroundColor Red
+}
+
+# Step 3: Verify the add-in is listening
+Write-Host "[3/3] Checking if Fusion MCP add-in is listening on port $Port..."
+$listening = netstat -ano | Select-String "127\.0\.0\.1:$Port.*LISTENING"
+if ($listening) {
+    Write-Host "  OK: Add-in appears active on 127.0.0.1:$Port" -ForegroundColor Green
+} else {
+    Write-Host "  NOTE: Nothing on 127.0.0.1:$Port yet - start Fusion and enable the MCP add-in first" -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "Bridge setup complete." -ForegroundColor Green
+Write-Host ""
+Write-Host "Next steps:"
+Write-Host "  1. Open Fusion 360 and enable the MCP add-in (if not already)"
+Write-Host "  2. Confirm the add-in port matches: $Port"
+Write-Host "     If it differs, re-run: .\fusion-mcp-bridge.ps1 -Port <actual-port>"
+Write-Host "  3. From inside the devcontainer, test connectivity:"
+Write-Host "     python3 -c ""import socket; s=socket.socket(); s.settimeout(3); s.connect(('host.docker.internal',$Port)); print('OK'); s.close()"""
+Write-Host "  4. Configure your MCP client to use devcontainer/fusion-mcp-wrapper.sh"
+Write-Host "     (see devcontainer/README.md for client config examples)"
+Write-Host ""
+Write-Host "To remove all rules: .\fusion-mcp-bridge.ps1 -Remove"

--- a/devcontainer/fusion-mcp-wrapper.sh
+++ b/devcontainer/fusion-mcp-wrapper.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Wrapper for running fusion360-mcp-server from inside a Docker devcontainer.
+#
+# The fusion360-mcp-server Python process connects to localhost:9876 to reach
+# the Fusion add-in. From inside a Docker container, "localhost" is the
+# container itself — not the host running Fusion. This wrapper starts a Python
+# TCP relay that forwards localhost:9876 → host.docker.internal:9876, then
+# execs the MCP server, which connects to localhost:9876 unchanged.
+#
+# Combined with a netsh portproxy + firewall rule on the Windows host
+# (see fusion-mcp-bridge.ps1), this lets MCP clients running in a devcontainer
+# reach the Fusion add-in transparently.
+#
+# Configure your MCP client's stdio command to point at this script. Example:
+#   .vscode/mcp.json or .claude/settings.json:
+#     "command": "/absolute/path/to/devcontainer/fusion-mcp-wrapper.sh"
+
+set -e
+
+# Start TCP relay: container localhost:9876 → host.docker.internal:9876
+python3 - <<'EOF' &
+import socket, threading
+
+def pipe(src, dst):
+    try:
+        while chunk := src.recv(4096):
+            dst.sendall(chunk)
+    finally:
+        src.close()
+        dst.close()
+
+srv = socket.socket()
+srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+srv.bind(('127.0.0.1', 9876))
+srv.listen(5)
+while True:
+    client, _ = srv.accept()
+    try:
+        remote = socket.socket()
+        remote.connect(('host.docker.internal', 9876))
+        for a, b in [(client, remote), (remote, client)]:
+            threading.Thread(target=pipe, args=(a, b), daemon=True).start()
+    except Exception:
+        client.close()
+EOF
+
+# Let the relay bind before the MCP server tries to connect
+sleep 0.5
+
+# Locate uvx — prefer PATH, fall back to uv's default install location
+UVX="$(command -v uvx || true)"
+if [ -z "$UVX" ] && [ -x "${HOME}/.local/bin/uvx" ]; then
+    UVX="${HOME}/.local/bin/uvx"
+fi
+if [ -z "$UVX" ]; then
+    echo "ERROR: uvx not found. Install uv first:" >&2
+    echo "  curl -LsSf https://astral.sh/uv/install.sh | sh" >&2
+    exit 1
+fi
+
+exec "$UVX" fusion360-mcp-server --mode socket


### PR DESCRIPTION
# Add devcontainer support for Docker-based MCP clients

## Summary

Adds a `devcontainer/` directory with two scripts and a setup guide that let `fusion360-mcp-server` work from inside a Docker devcontainer (VS Code Dev Containers, Cursor's container support, etc.) while Fusion 360 runs on the Windows host.

The README mentions Claude Code is supported, but the common case where Claude Code (or another MCP client) runs inside a containerized dev environment isn't currently documented and doesn't work out of the box. This change makes that path turnkey.

## What's added

1. **`devcontainer/fusion-mcp-wrapper.sh`** — a thin wrapper around `uvx fusion360-mcp-server --mode socket`. Starts a Python TCP relay forwarding the container's `localhost:9876` to `host.docker.internal:9876`, then execs the server. The MCP server connects to `localhost:9876` unchanged; the relay bridges to the Windows host transparently. Pure Python stdlib, no extra dependencies.

2. **`devcontainer/fusion-mcp-bridge.ps1`** — Windows-side one-shot setup script (run once as Administrator). Discovers Docker bridge adapter IPs at runtime (172.16–31.x range, avoiding LAN/VPN adapters), adds a `netsh portproxy` rule per adapter forwarding to `127.0.0.1:9876`, and creates a Windows Firewall inbound rule scoped to those Docker subnets only. Idempotent, persistent across reboots, has a `-Remove` flag for cleanup.

3. **`devcontainer/README.md`** — full setup guide with architecture diagram, step-by-step, MCP client config examples for Claude Code / VS Code MCP / Cursor, and a troubleshooting table.

## Why this is necessary

`fusion360-mcp-server` (the Python process) is hardcoded to connect to `localhost:9876`. From inside a Docker container, three things break:

1. Container `localhost` is the container itself, not the host
2. The Fusion add-in binds to `127.0.0.1` on Windows, so traffic from the Docker subnet (e.g. `host.docker.internal`) gets dropped at the listening interface
3. Windows Firewall blocks inbound from the Docker network by default

The wrapper + bridge combination solves all three. Rather than asking the add-in to bind on `0.0.0.0` (which would expose the Fusion API on every interface, including LAN and VPN), the bridge keeps the add-in localhost-only and scopes the portproxy + firewall rule to the Docker bridge subnet.

## Verified end-to-end

Tested from a Debian-based devcontainer running on Docker Desktop / WSL2 / Windows 11:

1. `python3 -c "import socket; ..."` to `host.docker.internal:9876` connects
2. MCP `initialize` handshake through the wrapper returns `serverInfo.name=fusion360-mcp-server v1.27.0`
3. MCP client sees the server as connected and can call tools

## Notes

1. No changes to existing files — purely additive.
2. The wrapper uses `host.docker.internal`, which Docker Desktop populates automatically. Pure Docker Engine in WSL2 (without Docker Desktop) needs `--add-host=host.docker.internal:host-gateway` in `runArgs`.
3. The bridge script discovers adapter IPs at runtime so it works regardless of Docker network reconfiguration.

Happy to iterate if you'd prefer a different file layout or want the wrapper to live elsewhere.
