### PR TITLE
Fix import_mesh on current Fusion builds (MeshBodies.addByFile removed)

### DIFF
--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -1757,7 +1757,14 @@ class CommandHandler:
                 f"Unknown units '{units}'. Expected one of: {sorted(unit_map)}"
             )
 
-        mesh_body = target.meshBodies.addByFile(file_path, unit_map[units])
+        mesh_bodies = target.meshBodies
+        if hasattr(mesh_bodies, "addByFile"):
+            mesh_body = mesh_bodies.addByFile(file_path, unit_map[units])
+        else:
+            # Current Fusion API: MeshBodies.add() (addByFile was removed).
+            # add() returns a MeshBodyList; take the first body.
+            added = mesh_bodies.add(file_path, unit_map[units])
+            mesh_body = added.item(0) if hasattr(added, "item") else added
 
         bb = mesh_body.boundingBox
         return {


### PR DESCRIPTION
## Problem

`import_mesh` fails on current Fusion 360 builds (tested on the Aug 2026 production build, macOS) with:

```
'MeshBodies' object has no attribute 'addByFile'
```

Autodesk removed `MeshBodies.addByFile()`; the current API is `MeshBodies.add(fullFilename, units)`, which returns a `MeshBodyList` rather than a single body.

## Fix

Try `addByFile` for older builds, fall back to `add()` and take the first body from the returned list:

```python
mesh_bodies = target.meshBodies
if hasattr(mesh_bodies, "addByFile"):
    mesh_body = mesh_bodies.addByFile(file_path, unit_map[units])
else:
    added = mesh_bodies.add(file_path, unit_map[units])
    mesh_body = added.item(0) if hasattr(added, "item") else added
```

## Verification

Ran live against Fusion (Aug 2026 build) through the socket add-in: batch-imported 19 STL files (3.9k–24k triangles each) into a design — all imported with correct names, bounding boxes returned as expected. `render_view` confirmed geometry visually.

Thanks for building this — we're an FTC youth robotics org using it with students (via a fork).

🤖 Generated with [Claude Code](https://claude.com/claude-code)