### PR TITLE
fix(create_hole): drill the requested hole, in the requested body

### DIFF
--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -22,6 +22,7 @@ import adsk.fusion
 
 from . import get_logger
 from . import hints as _hints
+from . import hole_geometry as _hole_geom
 
 log = get_logger("handler")
 
@@ -1116,40 +1117,75 @@ class CommandHandler:
             else root.bRepBodies.item(body_index)
         )
 
-        # Find the target face
-        bbox = body.boundingBox
+        # Find the target face.
+        # Comparing bounding boxes is not enough: the side faces of a box reach
+        # the body's max Z too, so the first "hit" is usually a vertical face.
+        # Require a near-horizontal planar face that points up (or down).
+        if face_selection not in ("top", "bottom"):
+            raise RuntimeError(f"Unknown face_selection '{face_selection}'")
+        want_up = face_selection == "top"
+
         target_face = None
-        if face_selection == "top":
-            threshold = bbox.maxPoint.z - 0.001
-            for face in body.faces:
-                if face.boundingBox.maxPoint.z > threshold:
-                    target_face = face
-                    break
-        elif face_selection == "bottom":
-            threshold = bbox.minPoint.z + 0.001
-            for face in body.faces:
-                if face.boundingBox.minPoint.z < threshold:
-                    target_face = face
-                    break
+        best_key = None
+        for face in body.faces:
+            if adsk.core.Plane.cast(face.geometry) is None:
+                continue
+            # Use the evaluator: it reports the face's outward normal, whereas
+            # the underlying plane's normal ignores the face's orientation.
+            ok, normal = face.evaluator.getNormalAtPoint(face.pointOnFace)
+            if not ok or not _hole_geom.is_horizontal_face(normal.z, want_up):
+                continue
+            # Rank on the face's own extreme Z, not on an arbitrary point on
+            # it: within the tilt tolerance the two are not the same.
+            fbox = face.boundingBox
+            edge_z = fbox.maxPoint.z if want_up else fbox.minPoint.z
+            key = _hole_geom.face_rank_key(edge_z, face.area, want_up)
+            if best_key is None or key > best_key:
+                best_key, target_face = key, face
 
         if target_face is None:
-            raise RuntimeError(f"No face found for selection '{face_selection}'")
+            raise RuntimeError(
+                f"No near-horizontal {face_selection}-facing planar face on "
+                f"'{body.name}'"
+            )
 
-        # Create a sketch point for the hole center
+        # Place the hole centre. center_x / center_y are model-space XY, so the
+        # caller does not have to know the sketch's own coordinate system. Solve
+        # the face's plane for Z rather than reusing an arbitrary point on it.
+        plane = adsk.core.Plane.cast(target_face.geometry)
+        n, o = plane.normal, plane.origin
+        center_z = _hole_geom.plane_z_at(
+            (n.x, n.y, n.z), (o.x, o.y, o.z), center_x, center_y
+        )
         sketch = root.sketches.add(target_face)
-        center = adsk.core.Point3D.create(center_x, center_y, 0)
-        sketch_pt = sketch.sketchPoints.add(center)
+        sketch_pt = sketch.sketchPoints.add(
+            sketch.modelToSketchSpace(
+                adsk.core.Point3D.create(center_x, center_y, center_z)
+            )
+        )
 
-        # Create hole feature
+        # createSimpleInput() takes the DIAMETER -- "A ValueInput object that
+        # defines the diameter of the hole" -- not the radius.
         holes = root.features.holeFeatures
         hole_input = holes.createSimpleInput(
-            adsk.core.ValueInput.createByReal(diameter / 2)
+            adsk.core.ValueInput.createByReal(diameter)
         )
         hole_input.setPositionBySketchPoint(sketch_pt)
         hole_input.setDistanceExtent(adsk.core.ValueInput.createByReal(depth))
+        # Without this the hole cuts every body it happens to intersect.
+        # The property takes a plain list, not an ObjectCollection.
+        hole_input.participantBodies = [body]
 
         feat = holes.add(hole_input)
-        return {"feature_name": feat.name, "diameter": diameter, "depth": depth}
+        return {
+            "feature_name": feat.name,
+            "diameter": diameter,
+            "depth": depth,
+            "actual_diameter": feat.holeDiameter.value,
+            "cut_bodies": [b.name for b in feat.bodies],
+            # Where the request resolved to, not a measurement of the feature.
+            "resolved_center": [center_x, center_y, center_z],
+        }
 
     def rectangular_pattern(
         self,

--- a/addon/server/hole_geometry.py
+++ b/addon/server/hole_geometry.py
@@ -1,0 +1,50 @@
+"""Pure geometry helpers for ``create_hole``.
+
+Deliberately free of ``adsk`` imports so the face-picking and plane-solving
+rules can be unit-tested without a running Fusion instance.
+"""
+
+from __future__ import annotations
+
+# Minimum |normal.z| for a planar face to count as horizontal, i.e. to be a
+# candidate "top"/"bottom" face. 0.99995 allows roughly 0.6 degrees of tilt.
+HORIZONTAL_FACE_MIN_NZ = 0.99995
+
+
+def is_horizontal_face(
+    normal_z: float, want_up: bool, min_nz: float = HORIZONTAL_FACE_MIN_NZ
+) -> bool:
+    """True if a face with this outward normal faces up (or down) and is flat.
+
+    Comparing bounding boxes instead would also accept the *side* faces of a
+    box, whose bounding boxes reach the body's top too.
+    """
+    return (normal_z if want_up else -normal_z) >= min_nz
+
+
+def face_rank_key(edge_z: float, area: float, want_up: bool) -> tuple[float, float]:
+    """Sort key picking the highest (or lowest) face, ties going to the larger.
+
+    *edge_z* is the face's own extreme Z (top of its bounding box when looking
+    for a top face). Within the tilt tolerance that is not the same as the Z of
+    an arbitrary point on the face.
+    """
+    return (edge_z if want_up else -edge_z, area)
+
+
+def plane_z_at(
+    normal: tuple[float, float, float],
+    origin: tuple[float, float, float],
+    x: float,
+    y: float,
+) -> float:
+    """Z where the vertical line through (*x*, *y*) meets the plane.
+
+    Any point on the face has the right Z only if the face is exactly
+    horizontal, so solve the plane instead of reusing ``face.pointOnFace``.
+    """
+    nx, ny, nz = normal
+    ox, oy, oz = origin
+    if nz == 0:
+        raise ValueError("plane is vertical: no unique Z above (x, y)")
+    return oz - (nx * (x - ox) + ny * (y - oy)) / nz

--- a/src/fusion360_mcp/mock.py
+++ b/src/fusion360_mcp/mock.py
@@ -300,10 +300,16 @@ def _draw_arc(p: dict) -> dict:
 
 
 def _create_hole(p: dict) -> dict:
+    body = p.get("body_name") or f"Body{p.get('body_index', 0) + 1}"
+    diameter = p.get("diameter", 0.5)
     return {
-        "body_name": p.get("body_name", "Body1"),
-        "diameter": p.get("diameter", 0.5),
+        "feature_name": "Hole_mock",
+        "body_name": body,
+        "diameter": diameter,
         "depth": p.get("depth", 1),
+        "actual_diameter": diameter,
+        "cut_bodies": [body],
+        "resolved_center": [p.get("center_x", 0), p.get("center_y", 0), 0.0],
     }
 
 

--- a/src/fusion360_mcp/tools.py
+++ b/src/fusion360_mcp/tools.py
@@ -453,9 +453,22 @@ TOOLS: list[dict] = [
                     "type": "string",
                     "enum": ["top", "bottom"],
                     "default": "top",
+                    "description": (
+                        "Drill into the highest up-facing (top) or lowest "
+                        "down-facing (bottom) planar face, which must be "
+                        "near-horizontal (within ~0.6 deg)"
+                    ),
                 },
-                "center_x": {"type": "number", "default": 0},
-                "center_y": {"type": "number", "default": 0},
+                "center_x": {
+                    "type": "number",
+                    "default": 0,
+                    "description": "Hole centre X in model space (cm)",
+                },
+                "center_y": {
+                    "type": "number",
+                    "default": 0,
+                    "description": "Hole centre Y in model space (cm)",
+                },
             },
         },
     },

--- a/tests/test_hole_geometry.py
+++ b/tests/test_hole_geometry.py
@@ -1,0 +1,192 @@
+"""Tests for create_hole's face picking and plane solving.
+
+``addon/server/hole_geometry.py`` is loaded by path: the addon package
+imports Fusion's ``adsk`` runtime, which isn't installable here, but this
+module deliberately has no such dependency.
+
+The AST guards at the bottom cover the two things that can only be seen at
+the call site into Fusion's API, in the same spirit as test_addon_sync.py.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import math
+from pathlib import Path
+
+import pytest
+
+ADDON_SERVER = Path(__file__).resolve().parent.parent / "addon" / "server"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"cannot load {path}"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hole_geometry = _load(ADDON_SERVER / "hole_geometry.py", "hole_geometry")
+
+
+def _nz(degrees_of_tilt: float) -> float:
+    return math.cos(math.radians(degrees_of_tilt))
+
+
+class TestIsHorizontalFace:
+    def test_accepts_the_face_pointing_the_requested_way(self):
+        assert hole_geometry.is_horizontal_face(1.0, want_up=True)
+        assert hole_geometry.is_horizontal_face(-1.0, want_up=False)
+
+    def test_rejects_the_face_pointing_the_other_way(self):
+        assert not hole_geometry.is_horizontal_face(-1.0, want_up=True)
+        assert not hole_geometry.is_horizontal_face(1.0, want_up=False)
+
+    def test_rejects_a_vertical_face(self):
+        # The side faces of a box share the top face's bounding-box max Z,
+        # which is how a "top" search used to end up drilling sideways.
+        assert not hole_geometry.is_horizontal_face(0.0, want_up=True)
+        assert not hole_geometry.is_horizontal_face(0.0, want_up=False)
+
+    @pytest.mark.parametrize("tilt", [0.0, 0.5])
+    def test_accepts_a_face_within_tolerance(self, tilt):
+        assert hole_geometry.is_horizontal_face(_nz(tilt), want_up=True)
+
+    @pytest.mark.parametrize("tilt", [1.0, 5.0, 45.0])
+    def test_rejects_a_slanted_face(self, tilt):
+        assert not hole_geometry.is_horizontal_face(_nz(tilt), want_up=True)
+
+
+class TestFaceRankKey:
+    def test_top_prefers_the_highest_face(self):
+        keys = [hole_geometry.face_rank_key(z, 1.0, want_up=True) for z in (0.0, 5.0)]
+        assert max(keys) == keys[1]
+
+    def test_bottom_prefers_the_lowest_face(self):
+        keys = [hole_geometry.face_rank_key(z, 1.0, want_up=False) for z in (0.0, 5.0)]
+        assert max(keys) == keys[0]
+
+    def test_ties_go_to_the_larger_face(self):
+        small = hole_geometry.face_rank_key(2.0, 1.0, want_up=True)
+        large = hole_geometry.face_rank_key(2.0, 9.0, want_up=True)
+        assert max(small, large) == large
+
+
+class TestPlaneZAt:
+    def test_horizontal_plane_keeps_its_height_everywhere(self):
+        z = hole_geometry.plane_z_at((0, 0, 1), (0, 0, 0.5), 22.0, 1.5)
+        assert z == pytest.approx(0.5)
+
+    def test_tilted_plane_z_follows_the_requested_xy(self):
+        # 45 degrees about Y: the plane through the origin has z == x.
+        n = (-math.sqrt(0.5), 0.0, math.sqrt(0.5))
+        assert hole_geometry.plane_z_at(n, (0, 0, 0), 3.0, 99.0) == pytest.approx(3.0)
+
+    def test_tilted_plane_z_differs_from_an_arbitrary_point_on_it(self):
+        # Reusing face.pointOnFace instead of solving would put the hole
+        # centre off the requested location on any non-horizontal face.
+        n = (-math.sqrt(0.5), 0.0, math.sqrt(0.5))
+        arbitrary_point_z = 0.0
+        assert hole_geometry.plane_z_at(n, (0, 0, 0), 3.0, 0.0) != arbitrary_point_z
+
+    def test_vertical_plane_is_rejected(self):
+        with pytest.raises(ValueError):
+            hole_geometry.plane_z_at((1, 0, 0), (0, 0, 0), 1.0, 1.0)
+
+
+def _create_hole_ast() -> ast.FunctionDef:
+    tree = ast.parse((ADDON_SERVER / "command_handler.py").read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "create_hole":
+            return node
+    raise AssertionError("create_hole not found in command_handler.py")
+
+
+class TestCreateHoleCallSite:
+    """Guards for the Fusion API calls that unit tests can't reach."""
+
+    def test_faces_are_ranked_on_their_own_extreme_z(self):
+        # pointOnFace is an arbitrary sample point; within the tilt tolerance
+        # it is not the face's highest (or lowest) point.
+        ranked = [
+            node
+            for node in ast.walk(_create_hole_ast())
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "face_rank_key"
+        ]
+        assert len(ranked) == 1, "expected one face_rank_key() call in create_hole"
+        attrs = {
+            n.attr for n in ast.walk(_create_hole_ast()) if isinstance(n, ast.Attribute)
+        }
+        assert {"maxPoint", "minPoint"} <= attrs
+        assert "pointOnFace" not in ast.dump(ranked[0])
+
+    def test_diameter_is_not_scaled_before_createsimpleinput(self):
+        # createSimpleInput() takes the diameter, not the radius; halving it
+        # here silently produced holes at half the requested size.
+        for node in ast.walk(_create_hole_ast()):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "createSimpleInput"
+            ):
+                value = node.args[0]
+                assert (
+                    isinstance(value, ast.Call)
+                    and len(value.args) == 1
+                    and isinstance(value.args[0], ast.Name)
+                    and value.args[0].id == "diameter"
+                ), "createSimpleInput() must receive the diameter unmodified"
+                return
+        raise AssertionError("no createSimpleInput() call in create_hole")
+
+    def test_participant_bodies_is_the_target_body(self):
+        # Left unset, the hole cuts every body it happens to intersect; left
+        # empty it means the same thing.
+        values = [
+            node.value
+            for node in ast.walk(_create_hole_ast())
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Attribute) and target.attr == "participantBodies"
+        ]
+        assert values, "create_hole must set participantBodies"
+        assert [
+            [getattr(el, "id", None) for el in v.elts]
+            for v in values
+            if isinstance(v, ast.List)
+        ] == [["body"]], "participantBodies must be limited to the target body"
+
+    def test_hole_centre_is_converted_from_model_space(self):
+        # Feeding model XY straight into the face's sketch space put the hole
+        # somewhere else entirely; the point must go through the conversion.
+        converted = [
+            node
+            for node in ast.walk(_create_hole_ast())
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "modelToSketchSpace"
+        ]
+        assert len(converted) == 1, "hole centre must go through sketch conversion"
+        names = {n.id for n in ast.walk(converted[0]) if isinstance(n, ast.Name)}
+        assert {"center_x", "center_y", "center_z"} <= names
+
+        added = [
+            node
+            for node in ast.walk(_create_hole_ast())
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add"
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.value.attr == "sketchPoints"
+        ]
+        assert len(added) == 1, "expected one sketchPoints.add() in create_hole"
+        assert any(
+            isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Attribute)
+            and sub.func.attr == "modelToSketchSpace"
+            for sub in ast.walk(added[0])
+        ), "sketchPoints.add() must receive the converted point"

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -158,6 +158,28 @@ class TestMockFeatures:
         assert result["mirror_plane"] == "xz"
         assert "new_body_name" in result
 
+    def test_create_hole_reports_the_keys_agents_verify_against(self):
+        # actual_diameter / cut_bodies / resolved_center let a caller check
+        # what was made against what it asked for; mock mode must carry them.
+        result = mock_command(
+            "create_hole",
+            {
+                "diameter": 0.52,
+                "depth": 0.6,
+                "body_name": "Plate",
+                "center_x": 22,
+                "center_y": 1.5,
+            },
+        )
+        assert result["actual_diameter"] == 0.52
+        assert result["cut_bodies"] == ["Plate"]
+        assert result["resolved_center"][:2] == [22, 1.5]
+
+    def test_create_hole_falls_back_to_body_index(self):
+        result = mock_command("create_hole", {"diameter": 0.5, "body_index": 1})
+        assert result["body_name"] == "Body2"
+        assert result["cut_bodies"] == ["Body2"]
+
 
 class TestMockBodyOps:
     def test_move_body(self):


### PR DESCRIPTION
## Summary

`create_hole` could report success while producing a hole of **half the requested diameter**, in a **different body**, at a **different position**, drilled into a **sideways face**. Four independent defects lined up so that none of them was visible from the return value.

| | Before | After |
|---|---|---|
| `diameter=0.52` (cm) | 0.26 hole | 0.52 hole |
| target `body_name` | whichever body the hole intersected | the requested body |
| `center_x/center_y = (22, 1.5)` on a plate spanning x=20..24 | model `(-2, 3)` | model `(22, 1.5)` |
| `face_selection="top"` on a plate | a vertical side face | the top face |

## What was wrong

- **`createSimpleInput()` takes the diameter, not the radius.** The [API docs](https://help.autodesk.com/cloudhelp/ENU/Fusion-360-API/files/HoleFeatures_createSimpleInput.htm) say "A ValueInput object that defines the diameter of the hole", so passing `diameter / 2` halved every hole.
- **The `"top"` face search only compared bounding-box max Z.** A box's side faces reach the top too, so the first match was usually a vertical face. Faces are now required to be planar and near-horizontal (within ~0.6°) with their outward normal pointing the requested way; the face whose own extreme Z is highest wins, ties going to the larger. A body with no such face now raises instead of silently drilling into a slanted one.
- **`center_x` / `center_y` went straight into the face's own sketch space**, which has no fixed relation to model XY. They are now model-space XY, and Z is solved from the face's plane equation rather than taken from an arbitrary `pointOnFace`.
- **`participantBodies` was never set**, so [Fusion included every intersecting body](https://help.autodesk.com/cloudhelp/ENU/Fusion-360-API/files/HoleFeatureInput_participantBodies.htm). It is now limited to the target body.

## Breaking change

`center_x` / `center_y` are interpreted as **model-space XY**. Callers that compensated for the old sketch-space behaviour must pass model coordinates. The old behaviour was undocumented and put the hole in an unrelated place.

## Also

- The return value gains `actual_diameter` and `cut_bodies`, read back from the created feature, plus `resolved_center`, which reports where the request resolved to (not a measurement of the result). Mock mode returns the same keys, and the tool schema documents the coordinate space.
- The face and plane rules move to `addon/server/hole_geometry.py`, which imports no `adsk` and so can be unit-tested.

## Test plan

`tests/test_hole_geometry.py` covers the pure rules directly and adds AST guards for the call sites into Fusion that unit tests cannot reach, in the spirit of the existing `test_addon_sync.py` drift guards. Each of these mutations fails at least one test:

| Mutation | Failing test |
|---|---|
| `createByReal(diameter / 2)`, directly or via a variable | `test_diameter_is_not_scaled_before_createsimpleinput` |
| drop or empty `participantBodies` | `test_participant_bodies_is_the_target_body` |
| skip `modelToSketchSpace` | `test_hole_centre_is_converted_from_model_space` |
| rank faces on `pointOnFace.z` | `test_faces_are_ranked_on_their_own_extreme_z` |
| accept any face normal | `TestIsHorizontalFace` (5) |
| return the plane origin's Z | `TestPlaneZAt` (2) |

**In Fusion** (units cm, as the API takes them) — a 4×3×0.5 plate (`Body15`) beside a 10×10×10 cube (`Body14`) and a wedge whose only downward-facing face is slanted (`Body16`):

```
create_hole(body_name="Body15", diameter=0.52, depth=0.6,
            center_x=22, center_y=1.5, face_selection="top")
  -> actual_diameter 0.52, cut_bodies ['Body15'], resolved_center [22, 1.5, 0.5]
  -> Body15 volume 5.893814  (theory 6.0 - pi*0.26^2*0.5 = 5.893814)
  -> cylindrical face at (22.0, 1.5), diameter 0.52
  -> Body14 still 1000.0, Body16 still 4.0

create_hole(body_name="Body16", ..., face_selection="bottom")
  -> "No near-horizontal bottom-facing planar face on 'Body16'"
```

`pytest` passes (292, excluding `test_connection.py`, which needs to bind a socket) and `ruff check` is clean. The hunks added here are ruff-formatted; `ruff format --check` also flags some pre-existing drift in `tools.py` and `test_mock.py` that this PR leaves alone.

## Scope

`create_hole` only. `delete_all` has a separate problem — it swallows every `deleteMe()` exception and returns `{"deleted": True}` regardless, and `TimelineObject` has no `deleteMe()` at all, so its timeline walk never deletes anything — but that is a different change with a different test matrix, so it is deliberately not in this branch. Happy to open it separately if useful.