### PR TITLE
fix(parameters): a "mm" parameter is no longer created ten times too large

### DIFF
--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -22,6 +22,7 @@ import adsk.fusion
 
 from . import get_logger
 from . import hints as _hints
+from . import parameter_units as _param_units
 
 log = get_logger("handler")
 
@@ -2428,16 +2429,41 @@ class CommandHandler:
     def create_parameter(self, name: str, value: float, unit: str, comment: str = None):
         design = self._design()
         params = design.userParameters
-        params.add(name, adsk.core.ValueInput.createByReal(value), unit, comment or "")
-        return {"created": True, "name": name, "value": value, "unit": unit}
+        unit = _param_units.normalise_unit(unit)
+        # createByReal() is read in internal units (cm, radians), so a caller
+        # asking for 1000 mm would get 1000 cm labelled "mm".
+        value_input = _param_units.build_value_input(
+            value,
+            unit,
+            adsk.core.ValueInput.createByString,
+            adsk.core.ValueInput.createByReal,
+        )
+        param = params.add(name, value_input, unit, comment or "")
+        return {
+            "created": True,
+            "name": name,
+            "value": value,
+            "unit": unit,
+            "expression": param.expression,
+        }
 
     def set_parameter(self, name: str, value: float):
         design = self._design()
         param = design.userParameters.itemByName(name)
         if not param:
             raise RuntimeError(f"Parameter '{name}' not found")
-        param.value = value
-        return {"updated": True, "name": name, "value": value}
+        # Assigning .value would be read in internal units, silently rescaling
+        # any parameter whose unit is not the internal one. Write the
+        # expression, in the unit the parameter already declares.
+        unit = _param_units.normalise_unit(param.unit)
+        param.expression = _param_units.expression_for(value, unit)
+        return {
+            "updated": True,
+            "name": name,
+            "value": value,
+            "unit": unit,
+            "expression": param.expression,
+        }
 
     def delete_parameter(self, name: str):
         design = self._design()

--- a/addon/server/parameter_units.py
+++ b/addon/server/parameter_units.py
@@ -1,0 +1,42 @@
+"""Unit handling for user parameters.
+
+Fusion reads a bare real in its internal units -- centimetres for a length,
+radians for an angle -- so a value the caller meant as millimetres has to be
+handed over as a unit-bearing string instead. Kept free of ``adsk`` imports
+so the rules can be unit-tested without a running Fusion instance.
+"""
+
+from __future__ import annotations
+
+
+def normalise_unit(unit: str | None) -> str:
+    """Trim a unit to its canonical form; blank means unitless."""
+    return (unit or "").strip()
+
+
+def expression_for(value: float, unit: str | None) -> str:
+    """The expression text that stores *value* as *unit*.
+
+    A unitless parameter has nothing to interpolate, so it keeps the bare
+    number -- Fusion then reads it as internal units, which is what unitless
+    means.
+    """
+    unit = normalise_unit(unit)
+    return f"{value} {unit}" if unit else f"{value}"
+
+
+def needs_expression(unit: str | None) -> bool:
+    """True when the value must go through a string rather than a real."""
+    return bool(normalise_unit(unit))
+
+
+def build_value_input(value: float, unit: str | None, from_string, from_real):
+    """Build the ValueInput that preserves *unit*.
+
+    The two factories are ``ValueInput.createByString`` and
+    ``ValueInput.createByReal``; they are passed in so the choice between
+    them -- the thing that was wrong -- can be tested without ``adsk``.
+    """
+    if needs_expression(unit):
+        return from_string(expression_for(value, unit))
+    return from_real(value)

--- a/src/fusion360_mcp/mock.py
+++ b/src/fusion360_mcp/mock.py
@@ -445,16 +445,32 @@ def _get_parameters(_p: dict) -> dict:
 
 
 def _create_parameter(p: dict) -> dict:
+    value = p.get("value", 0)
+    # The addon trims the unit and treats blank as unitless; mirror both so
+    # mock and real modes agree. "unit" is required by the schema, so the
+    # default only covers a caller that omitted it entirely.
+    unit = ("mm" if p.get("unit") is None else p["unit"]).strip()
     return {
+        "created": True,
         "name": p.get("name", "param1"),
-        "value": p.get("value", 0),
-        "unit": p.get("unit", "mm"),
+        "value": value,
+        "unit": unit,
+        "expression": f"{value} {unit}" if unit else f"{value}",
         "comment": p.get("comment", ""),
     }
 
 
 def _set_parameter(p: dict) -> dict:
-    return {"name": p.get("name", "param1"), "value": p.get("value", 0)}
+    # The real handler reports the unit the target parameter already declares
+    # and the expression Fusion stored. Mock mode holds no design, so it
+    # cannot know either -- report null rather than invent "mm".
+    return {
+        "updated": True,
+        "name": p.get("name", "param1"),
+        "value": p.get("value", 0),
+        "unit": None,
+        "expression": None,
+    }
 
 
 def _delete_parameter(p: dict) -> dict:

--- a/src/fusion360_mcp/tools.py
+++ b/src/fusion360_mcp/tools.py
@@ -738,10 +738,16 @@ TOOLS: list[dict] = [
             "required": ["name", "value", "unit"],
             "properties": {
                 "name": {"type": "string", "description": "Parameter name"},
-                "value": {"type": "number", "description": "Numeric value"},
+                "value": {
+                    "type": "number",
+                    "description": "Numeric value, expressed in `unit`",
+                },
                 "unit": {
                     "type": "string",
-                    "description": "Unit expression (e.g. 'mm', 'cm', 'in', 'deg')",
+                    "description": (
+                        "Unit the value is given in (e.g. 'mm', 'cm', 'in', "
+                        "'deg'). Empty means unitless."
+                    ),
                 },
                 "comment": {"type": "string", "description": "Optional comment"},
             },
@@ -756,7 +762,13 @@ TOOLS: list[dict] = [
             "required": ["name", "value"],
             "properties": {
                 "name": {"type": "string", "description": "Parameter name"},
-                "value": {"type": "number", "description": "New numeric value"},
+                "value": {
+                    "type": "number",
+                    "description": (
+                        "New numeric value, expressed in the unit the "
+                        "parameter already declares"
+                    ),
+                },
             },
         },
     },

--- a/tests/test_parameter_units.py
+++ b/tests/test_parameter_units.py
@@ -1,0 +1,188 @@
+"""Tests for user-parameter units.
+
+``createByReal()`` is read in Fusion's internal units -- centimetres for a
+length, radians for an angle -- so handing it a value the caller meant as
+millimetres inflates it tenfold while the parameter still reads "mm". The
+rules live in ``addon/server/parameter_units.py``, which imports no ``adsk``
+and is loaded here by path.
+
+The AST guards cover the two call sites into Fusion's API, which unit tests
+cannot reach, in the same spirit as test_addon_sync.py.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from fusion360_mcp.mock import mock_command
+
+ADDON_SERVER = Path(__file__).resolve().parent.parent / "addon" / "server"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"cannot load {path}"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+parameter_units = _load(ADDON_SERVER / "parameter_units.py", "parameter_units")
+
+
+class TestExpressionFor:
+    @pytest.mark.parametrize(
+        ("value", "unit", "expected"),
+        [
+            (1000, "mm", "1000 mm"),
+            (1200, "mm", "1200 mm"),
+            (2.5, "cm", "2.5 cm"),
+            (90, "deg", "90 deg"),
+            (1, "in", "1 in"),
+        ],
+    )
+    def test_the_requested_unit_reaches_the_expression(self, value, unit, expected):
+        # The unit must survive into the expression -- writing the value
+        # against a fixed unit, or dropping it, is the bug being fixed.
+        assert parameter_units.expression_for(value, unit) == expected
+
+    @pytest.mark.parametrize("unit", ["", "   ", None])
+    def test_a_unitless_parameter_keeps_the_bare_number(self, unit):
+        assert parameter_units.expression_for(7, unit) == "7"
+
+    def test_surrounding_whitespace_is_trimmed(self):
+        assert parameter_units.expression_for(5, "  mm  ") == "5 mm"
+
+
+class TestNeedsExpression:
+    @pytest.mark.parametrize("unit", ["mm", "deg", " in "])
+    def test_a_unit_requires_the_string_form(self, unit):
+        assert parameter_units.needs_expression(unit)
+
+    @pytest.mark.parametrize("unit", ["", "   ", None])
+    def test_unitless_does_not(self, unit):
+        assert not parameter_units.needs_expression(unit)
+
+
+class TestNormaliseUnit:
+    @pytest.mark.parametrize(
+        ("given", "expected"), [("mm", "mm"), (" mm ", "mm"), (None, ""), ("", "")]
+    )
+    def test_normalisation(self, given, expected):
+        assert parameter_units.normalise_unit(given) == expected
+
+
+def _func(name: str) -> ast.FunctionDef:
+    tree = ast.parse((ADDON_SERVER / "command_handler.py").read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in command_handler.py")
+
+
+def _calls(node: ast.AST, attr: str) -> list[ast.Call]:
+    return [
+        n
+        for n in ast.walk(node)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == attr
+    ]
+
+
+class TestBuildValueInput:
+    """The choice between the two factories is the thing that was wrong."""
+
+    @staticmethod
+    def _factories():
+        calls = []
+        return (
+            calls,
+            lambda s: calls.append(("string", s)),
+            lambda v: calls.append(("real", v)),
+        )
+
+    @pytest.mark.parametrize(
+        ("value", "unit", "expected"),
+        [(1000, "mm", "1000 mm"), (90, "deg", "90 deg"), (2.5, "in", "2.5 in")],
+    )
+    def test_a_unit_goes_through_the_string_factory(self, value, unit, expected):
+        calls, from_string, from_real = self._factories()
+        parameter_units.build_value_input(value, unit, from_string, from_real)
+        assert calls == [("string", expected)]
+
+    @pytest.mark.parametrize("unit", ["", "   ", None])
+    def test_unitless_goes_through_the_real_factory(self, unit):
+        calls, from_string, from_real = self._factories()
+        parameter_units.build_value_input(7, unit, from_string, from_real)
+        assert calls == [("real", 7)]
+
+    def test_centimetres_still_carry_their_unit(self):
+        # cm happens to match Fusion's internal unit, so a bare real would
+        # look correct here -- it must still take the explicit path.
+        calls, from_string, from_real = self._factories()
+        parameter_units.build_value_input(3, "cm", from_string, from_real)
+        assert calls == [("string", "3 cm")]
+
+
+class TestCallSites:
+    def test_create_parameter_delegates_the_choice(self):
+        # Constructing a ValueInput inline here would put the branch back
+        # where it cannot be tested.
+        create = _func("create_parameter")
+        assert _calls(create, "build_value_input"), (
+            "create_parameter must go through build_value_input()"
+        )
+        assert not _calls(create, "createByString")
+        assert not _calls(create, "createByReal")
+
+    def test_set_parameter_writes_the_expression_not_the_value(self):
+        assigned = {
+            target.attr: node.value
+            for node in ast.walk(_func("set_parameter"))
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Attribute)
+        }
+        assert "value" not in assigned, "Parameter.value is read in internal units"
+        assert "expression" in assigned
+        built = _calls(assigned["expression"], "expression_for")
+        assert built, "the expression must come from expression_for()"
+        names = {n.id for n in ast.walk(built[0]) if isinstance(n, ast.Name)}
+        assert {"value", "unit"} <= names
+
+
+class TestMockContract:
+    def test_create_parameter_reports_the_resulting_expression(self):
+        result = mock_command(
+            "create_parameter", {"name": "frame_length", "value": 1000, "unit": "mm"}
+        )
+        assert result["expression"] == "1000 mm"
+
+    def test_create_parameter_trims_the_unit_like_the_addon(self):
+        result = mock_command(
+            "create_parameter", {"name": "padded", "value": 5, "unit": "  mm  "}
+        )
+        assert result["unit"] == "mm"
+        assert result["expression"] == "5 mm"
+
+    @pytest.mark.parametrize("unit", ["", "   "])
+    def test_create_parameter_keeps_a_blank_unit_unitless(self, unit):
+        # Blank means unitless in the addon; mock must not turn it into mm.
+        result = mock_command(
+            "create_parameter", {"name": "bare", "value": 7, "unit": unit}
+        )
+        assert result["unit"] == ""
+        assert result["expression"] == "7"
+
+    def test_set_parameter_does_not_invent_a_unit(self):
+        # set_parameter takes no unit; mock mode holds no design, so it cannot
+        # know what the target parameter declares.
+        result = mock_command("set_parameter", {"name": "frame_length", "value": 1200})
+        assert result["value"] == 1200
+        assert result["unit"] is None
+        assert result["expression"] is None


### PR DESCRIPTION
## Summary

`create_parameter(name="frame_length", value=1000, unit="mm")` created a parameter reading **`10000.00 mm`**. Every dimension driven by it came out ten times its intended size — a 1 m frame modelled as 10 m.

`ValueInput.createByReal()` is read in Fusion's internal units — centimetres for a length, radians for an angle — so 1000 was stored as 1000 cm and then labelled with the requested `"mm"`.

`set_parameter` had the same problem from the other side: assigning `Parameter.value` writes the internal value, so updating a `"mm"` parameter to 1200 set it to 1200 cm, and a `"deg"` parameter to 45 set it to 45 **radians**.

Both now go through an expression carrying the unit. A unitless parameter still takes a bare real, since there is no unit to express.

## Breaking change

`value` is now interpreted in the requested unit (`create_parameter`) or in the unit the parameter already declares (`set_parameter`).

Existing parameters are **not** migrated. Anyone who compensated for the tenfold inflation — passing `100` to get 1000 mm — must now pass the real figure. Parameters in `cm` are unaffected, since that is already the internal unit.

## Also

- Both return the `unit` and the `expression` Fusion actually stored, so a caller can check what was written rather than trusting the request.
- `mock` mode returns `null` for `set_parameter`'s `unit` and `expression`: it holds no design, so it cannot know what the target parameter declares, and must not invent `"mm"`. Its `create_parameter` trims a padded unit and treats a blank one as unitless, the way the addon does.
- The tool schema now says which unit `value` is expressed in — previously just "New numeric value".

## Test plan

The rules, **including the choice between the two `ValueInput` factories**, live in `addon/server/parameter_units.py`, which imports no `adsk`. The factories are injected into `build_value_input()`, so the branch that was wrong is *executed* by the tests rather than inspected. `tests/test_parameter_units.py` covers mm/cm/in/deg/unitless/padded units, guards the two call sites into Fusion with AST checks so the helper cannot be bypassed, and pins the mock contract.

Each of these mutations fails at least one test:

| Mutation | Failing tests |
|---|---|
| invert the `needs_expression` branch | 7 |
| hard-code the unit in `expression_for` | 11 |
| drop the unit from `expression_for` | 6 |
| bypass `build_value_input` and call `createByReal` directly | 1 |
| restore `param.value = value` | 1 |
| let mock coerce a blank unit to `mm` | 2 |

**In Fusion**, checking the stored internal value as well as the expression:

```
create_parameter(value=1000, unit="mm")
  before -> expression "10000.00 mm"
  after  -> "1000 mm",  internal 100.0 cm
create_parameter(value=90,   unit="deg")   -> "90 deg", internal pi/2 rad
create_parameter(value=5,    unit="  mm  ")-> "5 mm",   internal 0.5 cm
set_parameter("v_deg", 45)                 -> "45 deg", internal pi/4 rad
```

Test parameters were deleted afterwards.

`pytest` passes (304, excluding `test_connection.py`, which needs to bind a socket) and `ruff check` is clean.

## Scope

Parameters only. Separate from #16.