### PR TITLE
Fix delete_all and check_interference calling non-existent Fusion APIs

### DIFF
--- a/addon/server/command_handler.py
+++ b/addon/server/command_handler.py
@@ -1810,15 +1810,83 @@ class CommandHandler:
         }
 
     def delete_all(self):
+        """Clear the active design: unwind the timeline, then sweep leftovers.
+
+        Returns counts of what was removed plus any per-item failures.  Raises
+        if the design is *not* empty afterwards — a caller that believes this
+        succeeded will happily build on a dirty document.
+        """
         design = self._design()
-        if hasattr(design, "timeline") and design.timeline.count > 0:
-            tl = design.timeline
+        root = design.rootComponent
+        deleted = {"timeline": 0, "bodies": 0, "sketches": 0}
+        errors = []
+
+        # Parametric: unwind newest-first.  NOTE: TimelineObject has no
+        # deleteMe() — that method lives on the *entity* it wraps.  Calling it
+        # on the TimelineObject raises AttributeError on every item.
+        tl = getattr(design, "timeline", None)
+        if tl is not None and tl.count > 0:
             for i in range(tl.count - 1, -1, -1):
+                name = "?"
                 try:
-                    tl.item(i).deleteMe()
-                except Exception:
-                    pass
-        return {"deleted": True}
+                    item = tl.item(i)
+                    name = item.name
+                    entity = item.entity
+                    if entity is None:
+                        errors.append(
+                            {"stage": "timeline", "index": i, "name": name,
+                             "error": "timeline item exposes no entity"}
+                        )
+                        continue
+                    entity.deleteMe()
+                    deleted["timeline"] += 1
+                except Exception as exc:
+                    errors.append(
+                        {"stage": "timeline", "index": i, "name": name,
+                         "error": f"{type(exc).__name__}: {exc}"}
+                    )
+
+        # Direct mode has no timeline; also catches anything the pass above
+        # could not remove.
+        for i in range(root.bRepBodies.count - 1, -1, -1):
+            name = "?"
+            try:
+                body = root.bRepBodies.item(i)
+                name = body.name
+                body.deleteMe()
+                deleted["bodies"] += 1
+            except Exception as exc:
+                errors.append(
+                    {"stage": "body", "index": i, "name": name,
+                     "error": f"{type(exc).__name__}: {exc}"}
+                )
+
+        for i in range(root.sketches.count - 1, -1, -1):
+            name = "?"
+            try:
+                sk = root.sketches.item(i)
+                name = sk.name
+                sk.deleteMe()
+                deleted["sketches"] += 1
+            except Exception as exc:
+                errors.append(
+                    {"stage": "sketch", "index": i, "name": name,
+                     "error": f"{type(exc).__name__}: {exc}"}
+                )
+
+        remaining = {
+            "bodies": root.bRepBodies.count,
+            "sketches": root.sketches.count,
+            "timeline": tl.count if tl is not None else 0,
+        }
+
+        if remaining["bodies"] or remaining["sketches"]:
+            raise RuntimeError(
+                f"delete_all did not clear the design — remaining: {remaining}. "
+                f"Deleted: {deleted}. Failures: {errors}"
+            )
+
+        return {"deleted": deleted, "remaining": remaining, "errors": errors}
 
     def undo(self):
         design = self._design()
@@ -2342,17 +2410,25 @@ class CommandHandler:
         if bodies.count < 2:
             raise RuntimeError("Need at least 2 components with bodies")
 
-        interference = root.interfere(bodies, include_coincident_faces)
+        # Interference analysis is a Design-level API.  Component has no
+        # interfere() method at all, so the previous call raised
+        # AttributeError for every caller.
+        design = self._design()
+        inp = design.createInterferenceInput(bodies)
+        inp.areCoincidentFacesIncluded = bool(include_coincident_faces)
+        interference = design.analyzeInterference(inp)
+
         results = []
-        for i in range(interference.interferenceResultCount):
-            result = interference.interferenceResult(i)
-            results.append(
-                {
-                    "body_one": result.entityOne.name,
-                    "body_two": result.entityTwo.name,
-                    "volume": result.interferenceBody.volume,
-                }
-            )
+        if interference is not None:
+            for i in range(interference.count):
+                result = interference.item(i)
+                results.append(
+                    {
+                        "body_one": result.entityOne.name,
+                        "body_two": result.entityTwo.name,
+                        "volume": result.interferenceBody.volume,
+                    }
+                )
 
         return {"interferences": results, "count": len(results)}
 

--- a/tests/test_addon_api_usage.py
+++ b/tests/test_addon_api_usage.py
@@ -1,0 +1,114 @@
+"""Guards against add-in code calling Fusion APIs that do not exist.
+
+The add-in cannot be imported here — it needs Fusion's ``adsk`` runtime — so
+these checks read it with ``ast`` the same way ``test_addon_sync.py`` does.
+
+Both bugs these cover shared a root cause: the failing call sat inside a bare
+``except Exception: pass``, so the tool reported success while doing nothing.
+Neither would have been caught by a test that only asserted on return values.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HANDLER = REPO_ROOT / "addon" / "server" / "command_handler.py"
+
+
+def _method(name: str) -> ast.FunctionDef:
+    tree = ast.parse(HANDLER.read_text())
+    for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
+        if cls.name != "CommandHandler":
+            continue
+        for node in cls.body:
+            if isinstance(node, ast.FunctionDef) and node.name == name:
+                return node
+    raise AssertionError(f"CommandHandler.{name} not found in {HANDLER}")
+
+
+def _called_attrs(node: ast.AST) -> set[str]:
+    """Every ``x.name(...)`` attribute name called within *node*."""
+    return {
+        n.func.attr
+        for n in ast.walk(node)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+    }
+
+
+def _has_silent_except(node: ast.AST) -> bool:
+    """True if any handler's whole body is ``pass``."""
+    for handler in (n for n in ast.walk(node) if isinstance(n, ast.ExceptHandler)):
+        if all(isinstance(stmt, ast.Pass) for stmt in handler.body):
+            return True
+    return False
+
+
+class TestDeleteAll:
+    def test_deletes_via_the_timeline_entity(self):
+        """TimelineObject has no deleteMe(); the entity it wraps does.
+
+        Calling deleteMe() on the TimelineObject raises AttributeError on
+        every item, so delete_all removed nothing at all.
+        """
+        node = _method("delete_all")
+        attrs = {
+            n.attr
+            for n in ast.walk(node)
+            if isinstance(n, ast.Attribute)
+        }
+        assert "entity" in attrs, (
+            "delete_all must reach the feature through TimelineObject.entity; "
+            "TimelineObject itself has no deleteMe()"
+        )
+
+    def test_does_not_swallow_failures(self):
+        node = _method("delete_all")
+        assert not _has_silent_except(node), (
+            "delete_all must not use a bare 'except: pass' — that is what let "
+            "it report success while deleting nothing"
+        )
+
+    def test_reports_what_it_did(self):
+        """The return value must carry enough to tell success from a no-op."""
+        node = _method("delete_all")
+        returns = [n for n in ast.walk(node) if isinstance(n, ast.Return)]
+        assert returns, "delete_all must return a result"
+        keys: set[str] = set()
+        for ret in returns:
+            if isinstance(ret.value, ast.Dict):
+                keys |= {
+                    k.value
+                    for k in ret.value.keys
+                    if isinstance(k, ast.Constant)
+                }
+        assert "remaining" in keys, (
+            "delete_all should report what is still in the design, so a "
+            "partial failure is visible to the caller"
+        )
+
+
+class TestCheckInterference:
+    def test_uses_the_design_level_api(self):
+        """Component.interfere() does not exist; the API is on Design."""
+        node = _method("check_interference")
+        called = _called_attrs(node)
+        assert "interfere" not in called, (
+            "Component.interfere() does not exist in the Fusion API — use "
+            "Design.createInterferenceInput() + Design.analyzeInterference()"
+        )
+        assert {"createInterferenceInput", "analyzeInterference"} <= called, (
+            "check_interference must go through the Design-level interference "
+            "API"
+        )
+
+    def test_iterates_results_as_a_collection(self):
+        """analyzeInterference returns a collection with .count / .item()."""
+        node = _method("check_interference")
+        attrs = {
+            n.attr for n in ast.walk(node) if isinstance(n, ast.Attribute)
+        }
+        assert "interferenceResultCount" not in attrs, (
+            "interferenceResultCount belongs to the old, non-existent API"
+        )


### PR DESCRIPTION
Two tools call Fusion API methods that don't exist. Both fail silently, so each reports success while doing nothing.

I hit these driving the add-in against a live Fusion 360 (2704.1.36, macOS).

## `delete_all` has never deleted anything

```python
tl.item(i).deleteMe()
```

`deleteMe()` belongs to the *entity* a timeline item wraps, not to the `TimelineObject` itself. Every iteration raises `AttributeError` straight into the surrounding `except Exception: pass`, and the tool returns `{"deleted": true}` with the design untouched.

That silence is the real problem — the caller believes the design is clear and builds into a dirty document. It cost me a while to find, because the symptom appears later and somewhere else.

Fixed by deleting through `item.entity.deleteMe()`, plus:

- a sweep of any remaining bodies and sketches, since **direct-mode designs have no timeline at all** and the old code skipped them entirely
- per-item failures returned rather than discarded
- raising if the design isn't actually empty afterwards

## `check_interference` raises on every call

```python
interference = root.interfere(bodies, include_coincident_faces)
```

`Component` has no `interfere()` method. Interference analysis is a **Design**-level API. `interferenceResultCount` on the next line is from the same non-existent interface; the real collection uses `.count` / `.item(i)`.

Replaced with `Design.createInterferenceInput()` + `Design.analyzeInterference()`.

## Tests

`tests/test_addon_api_usage.py`. The add-in can't be imported under pytest — it needs Fusion's `adsk` runtime — so these read it with `ast`, the way `test_addon_sync.py` already does.

They assert the **shape of the call**, not a return value, because a plausible return value is exactly what both bugs produced. One also asserts `delete_all` contains no bare `except: pass`, since that's what let the failure hide.

All five fail against `main` and pass with this change.

## Verified against live Fusion

| | |
|---|---|
| `delete_all` on a design with one body | 1 → 0 bodies, timeline emptied, no errors |
| `check_interference` on two components overlapping by a known volume | 1 interference, `4.0 cm³` — matches the expected 4000 mm³ |

`297 passed`, `ruff` clean.

## Scope

Bug fixes only — no new tools, no behaviour changes beyond making these two do what they already claim. The return shape of `delete_all` is richer (`deleted` / `remaining` / `errors` instead of `{"deleted": true}`); happy to reduce that to a bare boolean if you'd rather keep the payload stable, though the counts are what make a partial failure visible.

`check_interference`'s signature and return shape are unchanged.
